### PR TITLE
IE fix for file downloads

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,7 +35,7 @@ app.use(function(req, res, next) {
 // This is an IE fix for downloading files.
 app.use(function(req, res, next) {
     if(req.originalUrl.match(/\?download/) ) {
-        res.set('Content-Disposition', 'attachment;');
+        res.set('Content-Disposition', 'attachment');
     }
     next();
 });


### PR DESCRIPTION
This is a fix for IE downloads not working properly by setting a `Content-Disposition` attribute.

This fixes the error for IE11 (IE10 untested)

However, this does not fix the issue for MS Edge.
