### PR TITLE
Fix IE11 icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,7 +15,7 @@ var http        = require('http'),
     server,
     socket;
 
-require('dotenv').config();    
+require('dotenv').config();
 
 server = http.createServer(app);
 
@@ -30,7 +30,6 @@ socket = io.listen(server, {
 app.use(function(req, res, next) {
     res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
     res.header('Expires', '-1');
-    res.header('Pragma', 'no-cache');
     next();
 });
 

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ socket = io.listen(server, {
 // Since the caching is being performed in the browser, we set several headers to
 // get the client to respect our intentions.
 app.use(function(req, res, next) {
-    res.header('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+    res.header('Cache-Control', 'private, no-cache, must-revalidate');
     res.header('Expires', '-1');
     next();
 });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -283,8 +283,8 @@
     },
     "cloudcmd": {
       "version": "5.3.1",
-      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.16",
-      "resolved": "git://github.com/OSC/cloudcmd.git#873c24066a616bb418a7512d8ae41978907ee913",
+      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.17",
+      "resolved": "git://github.com/OSC/cloudcmd.git#8e9d76cf43e813b4c8ef04c8303c8431ff83ea89",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -338,9 +338,9 @@
           "resolved": "https://registry.npmjs.org/checkup/-/checkup-1.3.0.tgz"
         },
         "console-io": {
-          "version": "2.7.8",
+          "version": "2.7.9",
           "from": "console-io@>=2.7.1 <2.8.0",
-          "resolved": "https://registry.npmjs.org/console-io/-/console-io-2.7.8.tgz",
+          "resolved": "https://registry.npmjs.org/console-io/-/console-io-2.7.9.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
@@ -365,14 +365,14 @@
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.1.11",
+                      "version": "2.1.12",
                       "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.23.0",
-                          "from": "mime-db@>=1.23.0 <1.24.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                          "version": "1.24.0",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
@@ -569,14 +569,14 @@
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
-                      "version": "2.1.11",
+                      "version": "2.1.12",
                       "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.23.0",
-                          "from": "mime-db@>=1.23.0 <1.24.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                          "version": "1.24.0",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     }
@@ -595,14 +595,14 @@
               }
             },
             "spawnify": {
-              "version": "2.3.2",
+              "version": "2.3.4",
               "from": "spawnify@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "7.0.6",
-                  "from": "glob@>=7.0.0 <7.1.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                  "version": "7.1.0",
+                  "from": "glob@>=7.1.0 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -669,11 +669,6 @@
                     }
                   }
                 },
-                "tildify": {
-                  "version": "1.1.2",
-                  "from": "tildify@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz"
-                },
                 "untildify": {
                   "version": "2.1.0",
                   "from": "untildify@>=2.1.0 <2.2.0",
@@ -694,9 +689,9 @@
           }
         },
         "copymitter": {
-          "version": "1.8.9",
+          "version": "1.8.10",
           "from": "copymitter@>=1.8.0 <1.9.0",
-          "resolved": "https://registry.npmjs.org/copymitter/-/copymitter-1.8.9.tgz",
+          "resolved": "https://registry.npmjs.org/copymitter/-/copymitter-1.8.10.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
@@ -716,9 +711,9 @@
               "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
             },
             "glob": {
-              "version": "7.0.6",
-              "from": "glob@>=7.0.0 <7.1.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+              "version": "7.1.0",
+              "from": "glob@>=7.1.0 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
@@ -813,14 +808,14 @@
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.1.11",
+                      "version": "2.1.12",
                       "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.23.0",
-                          "from": "mime-db@>=1.23.0 <1.24.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                          "version": "1.24.0",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
@@ -1029,14 +1024,14 @@
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
-                      "version": "2.1.11",
+                      "version": "2.1.12",
                       "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.23.0",
-                          "from": "mime-db@>=1.23.0 <1.24.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                          "version": "1.24.0",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     }
@@ -1101,14 +1096,14 @@
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.1.11",
+                      "version": "2.1.12",
                       "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.23.0",
-                          "from": "mime-db@>=1.23.0 <1.24.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                          "version": "1.24.0",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
@@ -1317,14 +1312,14 @@
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
-                      "version": "2.1.11",
+                      "version": "2.1.12",
                       "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.23.0",
-                          "from": "mime-db@>=1.23.0 <1.24.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                          "version": "1.24.0",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     }
@@ -1384,14 +1379,14 @@
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "dependencies": {
                 "mime-types": {
-                  "version": "2.1.11",
-                  "from": "mime-types@>=2.1.6 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "version": "2.1.12",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.23.0",
-                      "from": "mime-db@>=1.23.0 <1.24.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                      "version": "1.24.0",
+                      "from": "mime-db@>=1.24.0 <1.25.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
                 },
@@ -1626,14 +1621,14 @@
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.11",
-                  "from": "mime-types@>=2.1.6 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
+                  "version": "2.1.12",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.23.0",
-                      "from": "mime-db@>=1.23.0 <1.24.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
+                      "version": "1.24.0",
+                      "from": "mime-db@>=1.24.0 <1.25.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
                 }
@@ -1734,14 +1729,14 @@
                       }
                     },
                     "spawnify": {
-                      "version": "2.3.2",
+                      "version": "2.3.4",
                       "from": "spawnify@>=2.3.0 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
                       "dependencies": {
                         "glob": {
-                          "version": "7.0.6",
-                          "from": "glob@>=7.0.0 <7.1.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                          "version": "7.1.0",
+                          "from": "glob@>=7.1.0 <8.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
                           "dependencies": {
                             "fs.realpath": {
                               "version": "1.0.0",
@@ -1809,9 +1804,9 @@
                           }
                         },
                         "tildify": {
-                          "version": "1.1.2",
-                          "from": "tildify@>=1.1.2 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz"
+                          "version": "1.2.0",
+                          "from": "tildify@>=1.2.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
                         },
                         "untildify": {
                           "version": "2.1.0",
@@ -1835,9 +1830,9 @@
               }
             },
             "remy": {
-              "version": "1.0.4",
+              "version": "1.0.5",
               "from": "remy@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "dependencies": {
                 "findit": {
                   "version": "2.0.0",
@@ -1845,9 +1840,9 @@
                   "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
                 },
                 "glob": {
-                  "version": "7.0.6",
-                  "from": "glob@>=7.0.0 <7.1.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                  "version": "7.1.0",
+                  "from": "glob@>=7.1.0 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
@@ -2043,9 +2038,9 @@
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                           "dependencies": {
                             "glob": {
-                              "version": "7.0.6",
+                              "version": "7.1.0",
                               "from": "glob@>=7.0.5 <8.0.0",
-                              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
                               "dependencies": {
                                 "fs.realpath": {
                                   "version": "1.0.0",
@@ -2182,9 +2177,9 @@
           "resolved": "https://registry.npmjs.org/ishtar/-/ishtar-1.3.5.tgz"
         },
         "jaguar": {
-          "version": "1.1.12",
+          "version": "1.1.13",
           "from": "jaguar@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/jaguar/-/jaguar-1.1.12.tgz",
+          "resolved": "https://registry.npmjs.org/jaguar/-/jaguar-1.1.13.tgz",
           "dependencies": {
             "findit": {
               "version": "2.0.0",
@@ -2192,9 +2187,9 @@
               "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
             },
             "glob": {
-              "version": "7.0.6",
-              "from": "glob@>=7.0.0 <7.1.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+              "version": "7.1.0",
+              "from": "glob@>=7.1.0 <8.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
@@ -2480,9 +2475,9 @@
               "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
             },
             "uc.micro": {
-              "version": "1.0.2",
+              "version": "1.0.3",
               "from": "uc.micro@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz"
             }
           }
         },
@@ -2497,9 +2492,9 @@
           "resolved": "https://registry.npmjs.org/minify/-/minify-2.0.11.tgz",
           "dependencies": {
             "clean-css": {
-              "version": "3.4.19",
+              "version": "3.4.20",
               "from": "clean-css@>=3.4.1 <3.5.0",
-              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.19.tgz",
+              "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
@@ -2545,9 +2540,9 @@
               }
             },
             "html-minifier": {
-              "version": "3.0.2",
+              "version": "3.1.0",
               "from": "html-minifier@>=3.0.1 <4.0.0",
-              "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.1.0.tgz",
               "dependencies": {
                 "change-case": {
                   "version": "3.0.0",
@@ -3085,7 +3080,7 @@
             },
             "itype": {
               "version": "1.0.2",
-              "from": "itype@>=1.0.1 <1.1.0",
+              "from": "itype@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz"
             }
           }
@@ -3101,9 +3096,9 @@
           "resolved": "https://registry.npmjs.org/remedy/-/remedy-1.3.2.tgz",
           "dependencies": {
             "remy": {
-              "version": "1.0.4",
+              "version": "1.0.5",
               "from": "remy@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "dependencies": {
                 "findit": {
                   "version": "2.0.0",
@@ -3111,9 +3106,9 @@
                   "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
                 },
                 "glob": {
-                  "version": "7.0.6",
-                  "from": "glob@>=7.0.0 <7.1.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+                  "version": "7.1.0",
+                  "from": "glob@>=7.1.0 <8.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.0.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "archiver": "^1.0.0",
     "base-uri": "^1.0.1",
-    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.16",
+    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.17",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "os-homedir": "^1.0.1",


### PR DESCRIPTION
* Fixes ie11 icons by removing pragma header for HTTPS. See: https://github.com/FortAwesome/Font-Awesome/wiki/Troubleshooting#im-hosting-fonts-on-my-server-and-icons-dont-show-up
  * We may need to later remove `no-store` from "Cache-Control" headers per the above, but for now it's working without the modification.
* Update to latest OSC/cloudcmd