### PR TITLE
Use nginx sendfile for file attachments

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
 OOD_FILE_EDITOR='/pun/sys/file-editor/edit'
 OOD_SHELL='/pun/sys/shell/ssh/default'
-OOD_DOWNLOAD='/pun/download'

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Log in as `wiag` user
 ```
 $ cd ~wiag/ood_portals/ondemand/sys
 $ git clone git@github.com:OSC/ood-fileexplorer.git files
-$ git checkout v1.1.1 # or whatever the lastest release tag is
+$ git checkout v1.1.2 # or whatever the lastest release tag is
 $ touch .env
 ```
 

--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ var http        = require('http'),
     fs          = require('fs'),
     path        = require('path'),
     cloudcmd    = require('cloudcmd'),
+    CloudFunc   = require('cloudcmd/lib/cloudfunc'),
     express     = require('express'),
     io          = require('socket.io'),
     HOME        = require('os-homedir')(),
@@ -34,11 +35,25 @@ app.use(function(req, res, next) {
 });
 
 // This is an IE fix for downloading files.
-app.use(function(req, res, next) {
-    if(req.originalUrl.match(/\?download/) ) {
-        res.set('Content-Disposition', 'attachment');
+app.get(BASE_URI + CloudFunc.apiURL + CloudFunc.FS + ':path(*)', function(req, res, next) {
+    var sendfile = req.get('X-Sendfile-Type'),
+        mapping  = req.get('X-Accel-Mapping'),
+        path     = req.params.path,
+        pattern,
+        redirect;
+    if (req.query.download) {
+        // generate redirect uri from file path
+        mapping = mapping.split('=');
+        pattern = '^' + mapping[0];
+        redirect = path.replace(new RegExp(pattern), mapping[1]);
+
+        // send attachment with redirect
+        res.attachment(path);
+        res.set(sendfile, redirect);
+        res.end();
+    } else {
+        next();
     }
-    next();
 });
 
 // Custom middleware to zip and send a directory to a browser.

--- a/app.js
+++ b/app.js
@@ -127,8 +127,7 @@ app.use(cloudcmd({
         treeroottitle: "Home Directory",
 
         file_editor: process.env.OOD_FILE_EDITOR,
-        shell: process.env.OOD_SHELL,
-        ood_download: process.env.OOD_DOWNLOAD
+        shell: process.env.OOD_SHELL
     }
 }));
 

--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ app.get(BASE_URI + CloudFunc.apiURL + CloudFunc.FS + ':path(*)', function(req, r
         path     = req.params.path,
         pattern,
         redirect;
-    if (req.query.download) {
+    if (sendfile && mapping && req.query.download) {
         // generate redirect uri from file path
         mapping = mapping.split('=');
         pattern = '^' + mapping[0];

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,86 +4,86 @@
   "dependencies": {
     "archiver": {
       "version": "1.1.0",
-      "from": "archiver@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/archiver/-/archiver-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.1.0.tgz",
       "dependencies": {
         "archiver-utils": {
           "version": "1.3.0",
-          "from": "archiver-utils@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.9",
-              "from": "graceful-fs@>=4.1.0 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
             },
             "lazystream": {
               "version": "1.0.0",
-              "from": "lazystream@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
             },
             "normalize-path": {
               "version": "2.0.1",
-              "from": "normalize-path@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
             }
           }
         },
         "async": {
           "version": "2.0.1",
-          "from": "async@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz"
         },
         "buffer-crc32": {
           "version": "0.2.5",
-          "from": "buffer-crc32@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz",
           "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
         },
         "glob": {
           "version": "7.1.1",
-          "from": "glob@>=7.0.0 <8.0.0",
+          "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
             "inflight": {
               "version": "1.0.5",
-              "from": "inflight@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "minimatch": {
               "version": "3.0.3",
-              "from": "minimatch@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.6",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -92,113 +92,113 @@
             },
             "once": {
               "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "dependencies": {
                 "wrappy": {
                   "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                 }
               }
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
             }
           }
         },
         "lodash": {
           "version": "4.16.4",
-          "from": "lodash@>=4.8.0 <5.0.0",
+          "from": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.16.4.tgz"
         },
         "readable-stream": {
           "version": "2.1.5",
-          "from": "readable-stream@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
             },
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+              "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         },
         "tar-stream": {
           "version": "1.5.2",
-          "from": "tar-stream@>=1.5.0 <2.0.0",
+          "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
           "dependencies": {
             "bl": {
               "version": "1.1.2",
-              "from": "bl@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
-                  "from": "readable-stream@>=2.0.5 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -207,17 +207,17 @@
             },
             "end-of-stream": {
               "version": "1.1.0",
-              "from": "end-of-stream@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
@@ -226,29 +226,29 @@
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "zip-stream": {
           "version": "1.1.0",
-          "from": "zip-stream@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.1.0.tgz",
           "dependencies": {
             "compress-commons": {
               "version": "1.1.0",
-              "from": "compress-commons@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.1.0.tgz",
               "dependencies": {
                 "crc32-stream": {
                   "version": "1.0.0",
-                  "from": "crc32-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-1.0.0.tgz"
                 },
                 "normalize-path": {
                   "version": "2.0.1",
-                  "from": "normalize-path@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                 }
               }
@@ -259,22 +259,22 @@
     },
     "base-uri": {
       "version": "1.1.0",
-      "from": "base-uri@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/base-uri/-/base-uri-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/base-uri/-/base-uri-1.1.0.tgz",
       "dependencies": {
         "url": {
           "version": "0.10.3",
-          "from": "url@>=0.10.3 <0.11.0",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "querystring@0.2.0",
+              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
@@ -283,299 +283,299 @@
     },
     "cloudcmd": {
       "version": "5.3.1",
-      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.18",
-      "resolved": "git://github.com/OSC/cloudcmd.git#98693587967ebc687c9810906fb523c254bafbde",
+      "from": "git://github.com/OSC/cloudcmd.git#f71a76acfa432019b1cb1dc3f6ade6e49c6d2027",
+      "resolved": "git://github.com/OSC/cloudcmd.git#f71a76acfa432019b1cb1dc3f6ade6e49c6d2027",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "chalk@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "checkup": {
           "version": "1.3.0",
-          "from": "checkup@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/checkup/-/checkup-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/checkup/-/checkup-1.3.0.tgz"
         },
         "console-io": {
           "version": "2.7.10",
-          "from": "console-io@>=2.7.1 <2.8.0",
+          "from": "https://registry.npmjs.org/console-io/-/console-io-2.7.10.tgz",
           "resolved": "https://registry.npmjs.org/console-io/-/console-io-2.7.10.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "express": {
               "version": "4.14.0",
-              "from": "express@>=4.14.0 <5.0.0",
+              "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.3.3",
-                  "from": "accepts@>=1.3.3 <1.4.0",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.6.1",
-                      "from": "negotiator@0.6.1",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
                 "array-flatten": {
                   "version": "1.1.1",
-                  "from": "array-flatten@1.1.1",
+                  "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
                 },
                 "content-disposition": {
                   "version": "0.5.1",
-                  "from": "content-disposition@0.5.1",
+                  "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
                 },
                 "content-type": {
                   "version": "1.0.2",
-                  "from": "content-type@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
                 },
                 "cookie": {
                   "version": "0.3.1",
-                  "from": "cookie@0.3.1",
+                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
                 },
                 "cookie-signature": {
                   "version": "1.0.6",
-                  "from": "cookie-signature@1.0.6",
+                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 },
                 "depd": {
                   "version": "1.1.0",
-                  "from": "depd@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 },
                 "encodeurl": {
                   "version": "1.0.1",
-                  "from": "encodeurl@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
                 },
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "escape-html@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "etag": {
                   "version": "1.7.0",
-                  "from": "etag@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "finalhandler": {
                   "version": "0.5.0",
-                  "from": "finalhandler@0.5.0",
+                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "dependencies": {
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "statuses@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
-                      "from": "unpipe@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                     }
                   }
                 },
                 "fresh": {
                   "version": "0.3.0",
-                  "from": "fresh@0.3.0",
+                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
                 },
                 "merge-descriptors": {
                   "version": "1.0.1",
-                  "from": "merge-descriptors@1.0.1",
+                  "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
                 },
                 "methods": {
                   "version": "1.1.2",
-                  "from": "methods@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "parseurl": {
                   "version": "1.3.1",
-                  "from": "parseurl@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
                 },
                 "path-to-regexp": {
                   "version": "0.1.7",
-                  "from": "path-to-regexp@0.1.7",
+                  "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
                 },
                 "proxy-addr": {
                   "version": "1.1.2",
-                  "from": "proxy-addr@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "dependencies": {
                     "forwarded": {
                       "version": "0.1.0",
-                      "from": "forwarded@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                     },
                     "ipaddr.js": {
                       "version": "1.1.1",
-                      "from": "ipaddr.js@1.1.1",
+                      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "6.2.0",
-                  "from": "qs@6.2.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                 },
                 "range-parser": {
                   "version": "1.2.0",
-                  "from": "range-parser@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
                 },
                 "send": {
                   "version": "0.14.1",
-                  "from": "send@0.14.1",
+                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "destroy@>=1.0.4 <1.1.0",
+                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.5.0",
-                      "from": "http-errors@>=1.5.0 <1.6.0",
+                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "setprototypeof": {
                           "version": "1.0.1",
-                          "from": "setprototypeof@1.0.1",
+                          "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "mime@1.3.4",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "statuses@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     }
                   }
                 },
                 "serve-static": {
                   "version": "1.11.1",
-                  "from": "serve-static@>=1.11.1 <1.12.0",
+                  "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
                   "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
                 },
                 "type-is": {
                   "version": "1.6.13",
-                  "from": "type-is@>=1.6.13 <1.7.0",
+                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "dependencies": {
                     "media-typer": {
                       "version": "0.3.0",
-                      "from": "media-typer@0.3.0",
+                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
@@ -584,112 +584,112 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 },
                 "vary": {
                   "version": "1.1.0",
-                  "from": "vary@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
                 }
               }
             },
             "socket.io": {
               "version": "1.5.0",
-              "from": "socket.io@>=1.5.0 <2.0.0",
+              "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.0.tgz",
               "dependencies": {
                 "engine.io": {
                   "version": "1.7.0",
-                  "from": "engine.io@1.7.0",
+                  "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.0.tgz",
                   "dependencies": {
                     "accepts": {
                       "version": "1.3.3",
-                      "from": "accepts@1.3.3",
+                      "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                       "dependencies": {
                         "mime-types": {
                           "version": "2.1.12",
-                          "from": "mime-types@>=2.1.11 <2.2.0",
+                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.24.0",
-                              "from": "mime-db@>=1.24.0 <1.25.0",
+                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                             }
                           }
                         },
                         "negotiator": {
                           "version": "0.6.1",
-                          "from": "negotiator@0.6.1",
+                          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
                           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                         }
                       }
                     },
                     "base64id": {
                       "version": "0.1.0",
-                      "from": "base64id@0.1.0",
+                      "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
                     },
                     "engine.io-parser": {
                       "version": "1.3.0",
-                      "from": "engine.io-parser@1.3.0",
+                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
                       "dependencies": {
                         "after": {
                           "version": "0.8.1",
-                          "from": "after@0.8.1",
+                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                         },
                         "arraybuffer.slice": {
                           "version": "0.0.6",
-                          "from": "arraybuffer.slice@0.0.6",
+                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                         },
                         "base64-arraybuffer": {
                           "version": "0.1.5",
-                          "from": "base64-arraybuffer@0.1.5",
+                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
                           "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz"
                         },
                         "blob": {
                           "version": "0.0.4",
-                          "from": "blob@0.0.4",
+                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                         },
                         "has-binary": {
                           "version": "0.1.6",
-                          "from": "has-binary@0.1.6",
+                          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "dependencies": {
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             }
                           }
                         },
                         "wtf-8": {
                           "version": "1.0.0",
-                          "from": "wtf-8@1.0.0",
+                          "from": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
                         }
                       }
                     },
                     "ws": {
                       "version": "1.1.1",
-                      "from": "ws@1.1.1",
+                      "from": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                       "dependencies": {
                         "options": {
                           "version": "0.0.6",
-                          "from": "options@>=0.0.5",
+                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                         },
                         "ultron": {
                           "version": "1.0.2",
-                          "from": "ultron@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                         }
                       }
@@ -698,113 +698,113 @@
                 },
                 "socket.io-parser": {
                   "version": "2.2.6",
-                  "from": "socket.io-parser@2.2.6",
+                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
                   "dependencies": {
                     "json3": {
                       "version": "3.3.2",
-                      "from": "json3@3.3.2",
+                      "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "benchmark": {
                       "version": "1.0.0",
-                      "from": "benchmark@1.0.0",
+                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                     }
                   }
                 },
                 "socket.io-client": {
                   "version": "1.5.0",
-                  "from": "socket.io-client@1.5.0",
+                  "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.0.tgz",
                   "dependencies": {
                     "engine.io-client": {
                       "version": "1.7.0",
-                      "from": "engine.io-client@1.7.0",
+                      "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.0.tgz",
                       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.0.tgz",
                       "dependencies": {
                         "component-emitter": {
                           "version": "1.1.2",
-                          "from": "component-emitter@1.1.2",
+                          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                         },
                         "component-inherit": {
                           "version": "0.0.3",
-                          "from": "component-inherit@0.0.3",
+                          "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
                         },
                         "engine.io-parser": {
                           "version": "1.3.0",
-                          "from": "engine.io-parser@1.3.0",
+                          "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
                           "dependencies": {
                             "after": {
                               "version": "0.8.1",
-                              "from": "after@0.8.1",
+                              "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                               "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                             },
                             "arraybuffer.slice": {
                               "version": "0.0.6",
-                              "from": "arraybuffer.slice@0.0.6",
+                              "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                               "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                             },
                             "base64-arraybuffer": {
                               "version": "0.1.5",
-                              "from": "base64-arraybuffer@0.1.5",
+                              "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
                               "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz"
                             },
                             "blob": {
                               "version": "0.0.4",
-                              "from": "blob@0.0.4",
+                              "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                             },
                             "has-binary": {
                               "version": "0.1.6",
-                              "from": "has-binary@0.1.6",
+                              "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                               "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                               "dependencies": {
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 }
                               }
                             },
                             "wtf-8": {
                               "version": "1.0.0",
-                              "from": "wtf-8@1.0.0",
+                              "from": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
                             }
                           }
                         },
                         "has-cors": {
                           "version": "1.1.0",
-                          "from": "has-cors@1.1.0",
+                          "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
                         },
                         "parsejson": {
                           "version": "0.0.1",
-                          "from": "parsejson@0.0.1",
+                          "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                           "dependencies": {
                             "better-assert": {
                               "version": "1.0.2",
-                              "from": "better-assert@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                               "dependencies": {
                                 "callsite": {
                                   "version": "1.0.0",
-                                  "from": "callsite@1.0.0",
+                                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                                 }
                               }
@@ -813,17 +813,17 @@
                         },
                         "parseqs": {
                           "version": "0.0.2",
-                          "from": "parseqs@0.0.2",
+                          "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                           "dependencies": {
                             "better-assert": {
                               "version": "1.0.2",
-                              "from": "better-assert@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                               "dependencies": {
                                 "callsite": {
                                   "version": "1.0.0",
-                                  "from": "callsite@1.0.0",
+                                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                                 }
                               }
@@ -832,66 +832,66 @@
                         },
                         "ws": {
                           "version": "1.1.1",
-                          "from": "ws@1.1.1",
+                          "from": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                           "dependencies": {
                             "options": {
                               "version": "0.0.6",
-                              "from": "options@>=0.0.5",
+                              "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                               "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                             },
                             "ultron": {
                               "version": "1.0.2",
-                              "from": "ultron@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                             }
                           }
                         },
                         "xmlhttprequest-ssl": {
                           "version": "1.5.1",
-                          "from": "xmlhttprequest-ssl@1.5.1",
+                          "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
                         },
                         "yeast": {
                           "version": "0.1.2",
-                          "from": "yeast@0.1.2",
+                          "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
                         }
                       }
                     },
                     "component-bind": {
                       "version": "1.0.0",
-                      "from": "component-bind@1.0.0",
+                      "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
                     },
                     "component-emitter": {
                       "version": "1.2.0",
-                      "from": "component-emitter@1.2.0",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
                     },
                     "object-component": {
                       "version": "0.0.3",
-                      "from": "object-component@0.0.3",
+                      "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
                     },
                     "indexof": {
                       "version": "0.0.1",
-                      "from": "indexof@0.0.1",
+                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     },
                     "parseuri": {
                       "version": "0.0.4",
-                      "from": "parseuri@0.0.4",
+                      "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "callsite@1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -900,49 +900,49 @@
                     },
                     "to-array": {
                       "version": "0.1.4",
-                      "from": "to-array@0.1.4",
+                      "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
                     },
                     "backo2": {
                       "version": "1.0.2",
-                      "from": "backo2@1.0.2",
+                      "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
                     }
                   }
                 },
                 "socket.io-adapter": {
                   "version": "0.4.0",
-                  "from": "socket.io-adapter@0.4.0",
+                  "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
                   "dependencies": {
                     "socket.io-parser": {
                       "version": "2.2.2",
-                      "from": "socket.io-parser@2.2.2",
+                      "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                       "dependencies": {
                         "debug": {
                           "version": "0.7.4",
-                          "from": "debug@0.7.4",
+                          "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                         },
                         "json3": {
                           "version": "3.2.6",
-                          "from": "json3@3.2.6",
+                          "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
                           "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                         },
                         "component-emitter": {
                           "version": "1.1.2",
-                          "from": "component-emitter@1.1.2",
+                          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "benchmark": {
                           "version": "1.0.0",
-                          "from": "benchmark@1.0.0",
+                          "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                         }
                       }
@@ -951,12 +951,12 @@
                 },
                 "has-binary": {
                   "version": "0.1.7",
-                  "from": "has-binary@0.1.7",
+                  "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
                   "dependencies": {
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     }
                   }
@@ -965,54 +965,54 @@
             },
             "spawnify": {
               "version": "2.3.4",
-              "from": "spawnify@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
-                  "from": "glob@>=7.1.0 <8.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "inflight": {
-                      "version": "1.0.5",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -1021,109 +1021,109 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
                 },
                 "untildify": {
                   "version": "2.1.0",
-                  "from": "untildify@>=2.1.0 <2.2.0",
+                  "from": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
                 },
                 "win32": {
                   "version": "0.9.11",
-                  "from": "win32@>=0.9.4 <0.10.0",
+                  "from": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz",
                   "resolved": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz"
                 }
               }
             },
             "tildify": {
               "version": "1.2.0",
-              "from": "tildify@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
             }
           }
         },
         "copymitter": {
           "version": "1.8.10",
-          "from": "copymitter@>=1.8.0 <1.9.0",
+          "from": "https://registry.npmjs.org/copymitter/-/copymitter-1.8.10.tgz",
           "resolved": "https://registry.npmjs.org/copymitter/-/copymitter-1.8.10.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "findit": {
               "version": "2.0.0",
-              "from": "findit@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
             },
             "glob": {
               "version": "7.1.1",
-              "from": "glob@>=7.1.0 <8.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
-                  "version": "1.0.5",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
-                  "from": "minimatch@>=3.0.2 <4.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -1132,19 +1132,19 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 }
               }
@@ -1153,253 +1153,253 @@
         },
         "criton": {
           "version": "1.0.0",
-          "from": "criton@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/criton/-/criton-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/criton/-/criton-1.0.0.tgz"
         },
         "dword": {
           "version": "3.0.16",
-          "from": "dword@>=3.0.3 <3.1.0",
+          "from": "https://registry.npmjs.org/dword/-/dword-3.0.16.tgz",
           "resolved": "https://registry.npmjs.org/dword/-/dword-3.0.16.tgz",
           "dependencies": {
             "ashify": {
               "version": "1.0.1",
-              "from": "ashify@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz"
             },
             "express": {
               "version": "4.14.0",
-              "from": "express@>=4.14.0 <5.0.0",
+              "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.3.3",
-                  "from": "accepts@>=1.3.3 <1.4.0",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.6.1",
-                      "from": "negotiator@0.6.1",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
                 "array-flatten": {
                   "version": "1.1.1",
-                  "from": "array-flatten@1.1.1",
+                  "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
                 },
                 "content-disposition": {
                   "version": "0.5.1",
-                  "from": "content-disposition@0.5.1",
+                  "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
                 },
                 "content-type": {
                   "version": "1.0.2",
-                  "from": "content-type@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
                 },
                 "cookie": {
                   "version": "0.3.1",
-                  "from": "cookie@0.3.1",
+                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
                 },
                 "cookie-signature": {
                   "version": "1.0.6",
-                  "from": "cookie-signature@1.0.6",
+                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <2.3.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "depd": {
                   "version": "1.1.0",
-                  "from": "depd@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 },
                 "encodeurl": {
                   "version": "1.0.1",
-                  "from": "encodeurl@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
                 },
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "escape-html@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "etag": {
                   "version": "1.7.0",
-                  "from": "etag@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "finalhandler": {
                   "version": "0.5.0",
-                  "from": "finalhandler@0.5.0",
+                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "dependencies": {
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "statuses@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
-                      "from": "unpipe@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                     }
                   }
                 },
                 "fresh": {
                   "version": "0.3.0",
-                  "from": "fresh@0.3.0",
+                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
                 },
                 "merge-descriptors": {
                   "version": "1.0.1",
-                  "from": "merge-descriptors@1.0.1",
+                  "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
                 },
                 "methods": {
                   "version": "1.1.2",
-                  "from": "methods@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "parseurl": {
                   "version": "1.3.1",
-                  "from": "parseurl@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
                 },
                 "path-to-regexp": {
                   "version": "0.1.7",
-                  "from": "path-to-regexp@0.1.7",
+                  "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
                 },
                 "proxy-addr": {
                   "version": "1.1.2",
-                  "from": "proxy-addr@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "dependencies": {
                     "forwarded": {
                       "version": "0.1.0",
-                      "from": "forwarded@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                     },
                     "ipaddr.js": {
                       "version": "1.1.1",
-                      "from": "ipaddr.js@1.1.1",
+                      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "6.2.0",
-                  "from": "qs@6.2.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                 },
                 "range-parser": {
                   "version": "1.2.0",
-                  "from": "range-parser@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
                 },
                 "send": {
                   "version": "0.14.1",
-                  "from": "send@0.14.1",
+                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "destroy@>=1.0.4 <1.1.0",
+                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.5.0",
-                      "from": "http-errors@>=1.5.0 <1.6.0",
+                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "setprototypeof": {
                           "version": "1.0.1",
-                          "from": "setprototypeof@1.0.1",
+                          "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "mime@1.3.4",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "statuses@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     }
                   }
                 },
                 "serve-static": {
                   "version": "1.11.1",
-                  "from": "serve-static@>=1.11.1 <1.12.0",
+                  "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
                   "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
                 },
                 "type-is": {
                   "version": "1.6.13",
-                  "from": "type-is@>=1.6.13 <1.7.0",
+                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "dependencies": {
                     "media-typer": {
                       "version": "0.3.0",
-                      "from": "media-typer@0.3.0",
+                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
@@ -1408,29 +1408,29 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 },
                 "vary": {
                   "version": "1.1.0",
-                  "from": "vary@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
                 }
               }
             },
             "patchfile": {
               "version": "1.0.7",
-              "from": "patchfile@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "dependencies": {
                 "daffy": {
                   "version": "1.0.3",
-                  "from": "daffy@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "dependencies": {
                     "diff-match-patch": {
                       "version": "1.0.0",
-                      "from": "diff-match-patch@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz"
                     }
                   }
@@ -1439,255 +1439,255 @@
             },
             "socket-file": {
               "version": "1.2.1",
-              "from": "socket-file@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz"
             }
           }
         },
         "edward": {
           "version": "3.0.7",
-          "from": "edward@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/edward/-/edward-3.0.7.tgz",
           "resolved": "https://registry.npmjs.org/edward/-/edward-3.0.7.tgz",
           "dependencies": {
             "ashify": {
               "version": "1.0.1",
-              "from": "ashify@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz"
             },
             "express": {
               "version": "4.14.0",
-              "from": "express@>=4.14.0 <5.0.0",
+              "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.3.3",
-                  "from": "accepts@>=1.3.3 <1.4.0",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.6.1",
-                      "from": "negotiator@0.6.1",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
                 "array-flatten": {
                   "version": "1.1.1",
-                  "from": "array-flatten@1.1.1",
+                  "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
                 },
                 "content-disposition": {
                   "version": "0.5.1",
-                  "from": "content-disposition@0.5.1",
+                  "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
                 },
                 "content-type": {
                   "version": "1.0.2",
-                  "from": "content-type@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
                 },
                 "cookie": {
                   "version": "0.3.1",
-                  "from": "cookie@0.3.1",
+                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
                 },
                 "cookie-signature": {
                   "version": "1.0.6",
-                  "from": "cookie-signature@1.0.6",
+                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "debug@>=2.2.0 <2.3.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "depd": {
                   "version": "1.1.0",
-                  "from": "depd@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 },
                 "encodeurl": {
                   "version": "1.0.1",
-                  "from": "encodeurl@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
                 },
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "escape-html@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "etag": {
                   "version": "1.7.0",
-                  "from": "etag@>=1.7.0 <1.8.0",
+                  "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "finalhandler": {
                   "version": "0.5.0",
-                  "from": "finalhandler@0.5.0",
+                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "dependencies": {
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "statuses@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
-                      "from": "unpipe@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                     }
                   }
                 },
                 "fresh": {
                   "version": "0.3.0",
-                  "from": "fresh@0.3.0",
+                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
                 },
                 "merge-descriptors": {
                   "version": "1.0.1",
-                  "from": "merge-descriptors@1.0.1",
+                  "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
                 },
                 "methods": {
                   "version": "1.1.2",
-                  "from": "methods@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
+                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "parseurl": {
                   "version": "1.3.1",
-                  "from": "parseurl@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
                 },
                 "path-to-regexp": {
                   "version": "0.1.7",
-                  "from": "path-to-regexp@0.1.7",
+                  "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
                 },
                 "proxy-addr": {
                   "version": "1.1.2",
-                  "from": "proxy-addr@>=1.1.2 <1.2.0",
+                  "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "dependencies": {
                     "forwarded": {
                       "version": "0.1.0",
-                      "from": "forwarded@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                     },
                     "ipaddr.js": {
                       "version": "1.1.1",
-                      "from": "ipaddr.js@1.1.1",
+                      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "6.2.0",
-                  "from": "qs@6.2.0",
+                  "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                 },
                 "range-parser": {
                   "version": "1.2.0",
-                  "from": "range-parser@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
                 },
                 "send": {
                   "version": "0.14.1",
-                  "from": "send@0.14.1",
+                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "destroy@>=1.0.4 <1.1.0",
+                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.5.0",
-                      "from": "http-errors@>=1.5.0 <1.6.0",
+                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "setprototypeof": {
                           "version": "1.0.1",
-                          "from": "setprototypeof@1.0.1",
+                          "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "mime@1.3.4",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "statuses@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     }
                   }
                 },
                 "serve-static": {
                   "version": "1.11.1",
-                  "from": "serve-static@>=1.11.1 <1.12.0",
+                  "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
                   "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
                 },
                 "type-is": {
                   "version": "1.6.13",
-                  "from": "type-is@>=1.6.13 <1.7.0",
+                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "dependencies": {
                     "media-typer": {
                       "version": "0.3.0",
-                      "from": "media-typer@0.3.0",
+                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "mime-db@>=1.24.0 <1.25.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
@@ -1696,29 +1696,29 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
+                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 },
                 "vary": {
                   "version": "1.1.0",
-                  "from": "vary@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
                 }
               }
             },
             "patchfile": {
               "version": "1.0.7",
-              "from": "patchfile@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "dependencies": {
                 "daffy": {
                   "version": "1.0.3",
-                  "from": "daffy@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "dependencies": {
                     "diff-match-patch": {
                       "version": "1.0.0",
-                      "from": "diff-match-patch@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz"
                     }
                   }
@@ -1727,252 +1727,252 @@
             },
             "socket-file": {
               "version": "1.2.1",
-              "from": "socket-file@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz"
             }
           }
         },
         "execon": {
           "version": "1.2.9",
-          "from": "execon@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/execon/-/execon-1.2.9.tgz",
           "resolved": "https://registry.npmjs.org/execon/-/execon-1.2.9.tgz"
         },
         "express": {
           "version": "4.13.4",
-          "from": "express@>=4.13.0 <4.14.0",
+          "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
           "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.2.13",
-              "from": "accepts@>=1.2.12 <1.3.0",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.1.12",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "from": "mime-db@>=1.24.0 <1.25.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
                 },
                 "negotiator": {
                   "version": "0.5.3",
-                  "from": "negotiator@0.5.3",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
                 }
               }
             },
             "array-flatten": {
               "version": "1.1.1",
-              "from": "array-flatten@1.1.1",
+              "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
             },
             "content-disposition": {
               "version": "0.5.1",
-              "from": "content-disposition@0.5.1",
+              "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
             },
             "content-type": {
               "version": "1.0.2",
-              "from": "content-type@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
             },
             "cookie": {
               "version": "0.1.5",
-              "from": "cookie@0.1.5",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "from": "cookie-signature@1.0.6",
+              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.1.0",
-              "from": "depd@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "escape-html": {
               "version": "1.0.3",
-              "from": "escape-html@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
             "etag": {
               "version": "1.7.0",
-              "from": "etag@>=1.7.0 <1.8.0",
+              "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
             },
             "finalhandler": {
               "version": "0.4.1",
-              "from": "finalhandler@0.4.1",
+              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "dependencies": {
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.3.0",
-              "from": "fresh@0.3.0",
+              "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "merge-descriptors": {
               "version": "1.0.1",
-              "from": "merge-descriptors@1.0.1",
+              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             },
             "methods": {
               "version": "1.1.2",
-              "from": "methods@>=1.1.2 <1.2.0",
+              "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <2.4.0",
+              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
+                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
+              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "path-to-regexp": {
               "version": "0.1.7",
-              "from": "path-to-regexp@0.1.7",
+              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
             },
             "proxy-addr": {
               "version": "1.0.10",
-              "from": "proxy-addr@>=1.0.10 <1.1.0",
+              "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
               "dependencies": {
                 "forwarded": {
                   "version": "0.1.0",
-                  "from": "forwarded@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                 },
                 "ipaddr.js": {
                   "version": "1.0.5",
-                  "from": "ipaddr.js@1.0.5",
+                  "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
                 }
               }
             },
             "qs": {
               "version": "4.0.0",
-              "from": "qs@4.0.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "range-parser": {
               "version": "1.0.3",
-              "from": "range-parser@>=1.0.3 <1.1.0",
+              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
             },
             "send": {
               "version": "0.13.1",
-              "from": "send@0.13.1",
+              "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
               "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
-                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                 },
                 "http-errors": {
                   "version": "1.3.1",
-                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "mime@1.3.4",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.10.3",
-              "from": "serve-static@>=1.10.2 <1.11.0",
+              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
               "dependencies": {
                 "send": {
                   "version": "0.13.2",
-                  "from": "send@0.13.2",
+                  "from": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "destroy@>=1.0.4 <1.1.0",
+                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.3.1",
-                      "from": "http-errors@>=1.3.1 <1.4.0",
+                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "mime@1.3.4",
+                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "ms@0.7.1",
+                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
-                      "from": "statuses@>=1.2.1 <1.3.0",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
@@ -1981,22 +1981,22 @@
             },
             "type-is": {
               "version": "1.6.13",
-              "from": "type-is@>=1.6.6 <1.7.0",
+              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
+                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.12",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "from": "mime-db@>=1.24.0 <1.25.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
@@ -2005,29 +2005,29 @@
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
+              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             },
             "vary": {
               "version": "1.0.1",
-              "from": "vary@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
             }
           }
         },
         "faust": {
           "version": "1.0.4",
-          "from": "faust@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/faust/-/faust-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/faust/-/faust-1.0.4.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
@@ -2036,61 +2036,78 @@
         },
         "files-io": {
           "version": "1.2.6",
-          "from": "files-io@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/files-io/-/files-io-1.2.6.tgz",
           "resolved": "https://registry.npmjs.org/files-io/-/files-io-1.2.6.tgz",
           "dependencies": {
             "extendy": {
               "version": "1.0.1",
-              "from": "extendy@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz"
             },
             "itype": {
               "version": "1.0.2",
-              "from": "itype@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz"
             }
           }
         },
         "flop": {
-          "version": "1.4.1",
-          "from": "flop@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/flop/-/flop-1.4.1.tgz",
+          "version": "1.4.2",
+          "from": "https://registry.npmjs.org/flop/-/flop-1.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/flop/-/flop-1.4.2.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "readify": {
-              "version": "2.0.2",
-              "from": "readify@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readify/-/readify-2.0.2.tgz",
+              "version": "3.0.0",
+              "from": "https://registry.npmjs.org/readify/-/readify-3.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/readify/-/readify-3.0.0.tgz",
               "dependencies": {
+                "currify": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/currify/-/currify-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/currify/-/currify-1.0.0.tgz"
+                },
+                "es6-promisify": {
+                  "version": "5.0.0",
+                  "from": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                  "dependencies": {
+                    "es6-promise": {
+                      "version": "4.0.5",
+                      "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz"
+                    }
+                  }
+                },
                 "nicki": {
                   "version": "1.2.11",
-                  "from": "nicki@>=1.2.2 <1.3.0",
+                  "from": "https://registry.npmjs.org/nicki/-/nicki-1.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/nicki/-/nicki-1.2.11.tgz",
                   "dependencies": {
                     "ischanged": {
                       "version": "1.0.17",
-                      "from": "ischanged@>=1.0.2 <1.1.0",
+                      "from": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
                       "resolved": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
                       "dependencies": {
                         "debug": {
                           "version": "2.2.0",
-                          "from": "debug@>=2.2.0 <2.3.0",
+                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "ms@0.7.1",
+                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
@@ -2099,54 +2116,54 @@
                     },
                     "spawnify": {
                       "version": "2.3.4",
-                      "from": "spawnify@>=2.3.0 <2.4.0",
+                      "from": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
                       "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "7.1.1",
-                          "from": "glob@>=7.1.0 <8.0.0",
+                          "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                           "dependencies": {
                             "fs.realpath": {
                               "version": "1.0.0",
-                              "from": "fs.realpath@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                             },
                             "inflight": {
-                              "version": "1.0.5",
-                              "from": "inflight@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                              "version": "1.0.6",
+                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.3",
-                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             },
                             "minimatch": {
                               "version": "3.0.3",
-                              "from": "minimatch@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.6",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.4.2",
-                                      "from": "balanced-match@>=0.4.1 <0.5.0",
+                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
+                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
@@ -2155,31 +2172,31 @@
                             },
                             "once": {
                               "version": "1.4.0",
-                              "from": "once@>=1.3.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.1",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                             }
                           }
                         },
                         "tildify": {
                           "version": "1.2.0",
-                          "from": "tildify@>=1.2.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
                         },
                         "untildify": {
                           "version": "2.1.0",
-                          "from": "untildify@>=2.1.0 <2.2.0",
+                          "from": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
                         }
                       }
@@ -2188,71 +2205,71 @@
                 },
                 "shortdate": {
                   "version": "1.2.0",
-                  "from": "shortdate@>=1.2.0 <1.3.0",
+                  "from": "https://registry.npmjs.org/shortdate/-/shortdate-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/shortdate/-/shortdate-1.2.0.tgz"
                 },
                 "squad": {
                   "version": "1.1.3",
-                  "from": "squad@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/squad/-/squad-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/squad/-/squad-1.1.3.tgz"
                 }
               }
             },
             "remy": {
               "version": "1.0.5",
-              "from": "remy@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "dependencies": {
                 "findit": {
                   "version": "2.0.0",
-                  "from": "findit@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
                 },
                 "glob": {
                   "version": "7.1.1",
-                  "from": "glob@>=7.1.0 <8.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "inflight": {
-                      "version": "1.0.5",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -2261,196 +2278,196 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.5.4",
-                  "from": "rimraf@>=2.5.0 <2.6.0",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
                 }
               }
             },
             "timem": {
               "version": "1.1.2",
-              "from": "timem@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz"
             },
             "trammel": {
               "version": "1.0.2",
-              "from": "trammel@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/trammel/-/trammel-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/trammel/-/trammel-1.0.2.tgz"
             },
             "win32": {
               "version": "0.9.11",
-              "from": "win32@>=0.9.10 <0.10.0",
+              "from": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz",
               "resolved": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz"
             }
           }
         },
         "format-io": {
           "version": "0.9.6",
-          "from": "format-io@>=0.9.6 <0.10.0",
+          "from": "https://registry.npmjs.org/format-io/-/format-io-0.9.6.tgz",
           "resolved": "https://registry.npmjs.org/format-io/-/format-io-0.9.6.tgz"
         },
         "freeport": {
           "version": "1.0.5",
-          "from": "freeport@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz"
         },
         "http-auth": {
           "version": "2.2.9",
-          "from": "http-auth@>=2.2.3 <2.3.0",
+          "from": "https://registry.npmjs.org/http-auth/-/http-auth-2.2.9.tgz",
           "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-2.2.9.tgz",
           "dependencies": {
             "node-uuid": {
               "version": "1.4.1",
-              "from": "node-uuid@1.4.1",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
             },
             "htpasswd": {
               "version": "2.2.2",
-              "from": "htpasswd@2.2.2",
+              "from": "https://registry.npmjs.org/htpasswd/-/htpasswd-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/htpasswd/-/htpasswd-2.2.2.tgz",
               "dependencies": {
                 "apache-md5": {
                   "version": "1.0.4",
-                  "from": "apache-md5@1.0.4",
+                  "from": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.0.4.tgz"
                 },
                 "commander": {
                   "version": "2.0.0",
-                  "from": "commander@2.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
                 },
                 "prompt": {
                   "version": "0.2.11",
-                  "from": "prompt@0.2.11",
+                  "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.11.tgz",
                   "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.11.tgz",
                   "dependencies": {
                     "pkginfo": {
                       "version": "0.4.0",
-                      "from": "pkginfo@>=0.0.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz"
                     },
                     "read": {
                       "version": "1.0.7",
-                      "from": "read@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
                       "dependencies": {
                         "mute-stream": {
                           "version": "0.0.6",
-                          "from": "mute-stream@>=0.0.4 <0.1.0",
+                          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
                         }
                       }
                     },
                     "revalidator": {
                       "version": "0.1.8",
-                      "from": "revalidator@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
                       "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                     },
                     "utile": {
                       "version": "0.2.1",
-                      "from": "utile@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
-                          "from": "async@>=0.2.9 <0.3.0",
+                          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                         },
                         "deep-equal": {
                           "version": "1.0.1",
-                          "from": "deep-equal@*",
+                          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
                         },
                         "i": {
                           "version": "0.3.5",
-                          "from": "i@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
                           "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz"
                         },
                         "mkdirp": {
                           "version": "0.5.1",
-                          "from": "mkdirp@>=0.0.0 <1.0.0",
+                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.8",
-                              "from": "minimist@0.0.8",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                             }
                           }
                         },
                         "ncp": {
                           "version": "0.4.2",
-                          "from": "ncp@>=0.4.0 <0.5.0",
+                          "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
                           "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                         },
                         "rimraf": {
                           "version": "2.5.4",
-                          "from": "rimraf@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                           "dependencies": {
                             "glob": {
                               "version": "7.1.1",
-                              "from": "glob@>=7.0.5 <8.0.0",
+                              "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                               "dependencies": {
                                 "fs.realpath": {
                                   "version": "1.0.0",
-                                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                                 },
                                 "inflight": {
-                                  "version": "1.0.5",
-                                  "from": "inflight@>=1.0.4 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                                  "version": "1.0.6",
+                                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "inherits": {
                                   "version": "2.0.3",
-                                  "from": "inherits@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                                 },
                                 "minimatch": {
                                   "version": "3.0.3",
-                                  "from": "minimatch@>=3.0.2 <4.0.0",
+                                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.6",
-                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.4.2",
-                                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                         },
                                         "concat-map": {
                                           "version": "0.0.1",
-                                          "from": "concat-map@0.0.1",
+                                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                         }
                                       }
@@ -2459,19 +2476,19 @@
                                 },
                                 "once": {
                                   "version": "1.4.0",
-                                  "from": "once@>=1.3.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
-                                      "from": "wrappy@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "path-is-absolute": {
                                   "version": "1.0.1",
-                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                                 }
                               }
@@ -2482,42 +2499,42 @@
                     },
                     "winston": {
                       "version": "0.6.2",
-                      "from": "winston@>=0.6.0 <0.7.0",
+                      "from": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
                       "resolved": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.1.22",
-                          "from": "async@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
                         },
                         "colors": {
                           "version": "0.6.2",
-                          "from": "colors@>=0.0.0 <1.0.0",
+                          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
                           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                         },
                         "cycle": {
                           "version": "1.0.3",
-                          "from": "cycle@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                         },
                         "eyes": {
                           "version": "0.1.8",
-                          "from": "eyes@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
                           "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                         },
                         "pkginfo": {
                           "version": "0.2.3",
-                          "from": "pkginfo@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
                         },
                         "request": {
                           "version": "2.9.203",
-                          "from": "request@>=2.9.0 <2.10.0",
+                          "from": "https://registry.npmjs.org/request/-/request-2.9.203.tgz",
                           "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz"
                         },
                         "stack-trace": {
                           "version": "0.0.9",
-                          "from": "stack-trace@>=0.0.0 <0.1.0",
+                          "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
                           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                         }
                       }
@@ -2526,12 +2543,12 @@
                 },
                 "apache-crypt": {
                   "version": "1.1.0",
-                  "from": "apache-crypt@1.1.0",
+                  "from": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.1.0.tgz",
                   "dependencies": {
                     "unix-crypt-td-js": {
                       "version": "1.0.0",
-                      "from": "unix-crypt-td-js@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz"
                     }
                   }
@@ -2542,64 +2559,64 @@
         },
         "ishtar": {
           "version": "1.3.5",
-          "from": "ishtar@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/ishtar/-/ishtar-1.3.5.tgz",
           "resolved": "https://registry.npmjs.org/ishtar/-/ishtar-1.3.5.tgz"
         },
         "jaguar": {
           "version": "1.1.13",
-          "from": "jaguar@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/jaguar/-/jaguar-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/jaguar/-/jaguar-1.1.13.tgz",
           "dependencies": {
             "findit": {
               "version": "2.0.0",
-              "from": "findit@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
             },
             "glob": {
               "version": "7.1.1",
-              "from": "glob@>=7.1.0 <8.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "from": "fs.realpath@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
-                  "version": "1.0.5",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
-                  "from": "minimatch@>=3.0.2 <4.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "balanced-match@>=0.4.1 <0.5.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -2608,58 +2625,58 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 }
               }
             },
             "tar-fs": {
-              "version": "1.13.2",
-              "from": "tar-fs@>=1.13.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.13.2.tgz",
+              "version": "1.14.0",
+              "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.14.0.tgz",
+              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.14.0.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "pump": {
                   "version": "1.0.1",
-                  "from": "pump@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <1.4.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
@@ -2668,12 +2685,12 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "once@>=1.3.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
@@ -2684,47 +2701,47 @@
             },
             "tar-stream": {
               "version": "1.5.2",
-              "from": "tar-stream@>=1.5.1 <1.6.0",
+              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
               "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.1.2",
-                  "from": "bl@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "from": "readable-stream@>=2.0.5 <2.1.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -2733,17 +2750,17 @@
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "from": "end-of-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
@@ -2752,49 +2769,49 @@
                 },
                 "readable-stream": {
                   "version": "2.1.5",
-                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -2803,88 +2820,88 @@
         },
         "join-io": {
           "version": "1.4.4",
-          "from": "join-io@>=1.4.0 <1.5.0",
+          "from": "https://registry.npmjs.org/join-io/-/join-io-1.4.4.tgz",
           "resolved": "https://registry.npmjs.org/join-io/-/join-io-1.4.4.tgz"
         },
         "jonny": {
           "version": "1.0.1",
-          "from": "jonny@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/jonny/-/jonny-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/jonny/-/jonny-1.0.1.tgz"
         },
         "markdown-it": {
           "version": "6.0.5",
-          "from": "markdown-it@>=6.0.0 <6.1.0",
+          "from": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.0.5.tgz",
           "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
-              "from": "argparse@>=1.0.7 <2.0.0",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.1.1",
-              "from": "entities@>=1.1.1 <1.2.0",
+              "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
             },
             "linkify-it": {
               "version": "1.2.4",
-              "from": "linkify-it@>=1.2.2 <1.3.0",
+              "from": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz",
               "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz"
             },
             "mdurl": {
               "version": "1.0.1",
-              "from": "mdurl@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
             },
             "uc.micro": {
               "version": "1.0.3",
-              "from": "uc.micro@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz"
             }
           }
         },
         "mellow": {
           "version": "2.0.2",
-          "from": "mellow@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/mellow/-/mellow-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/mellow/-/mellow-2.0.2.tgz"
         },
         "minify": {
           "version": "2.0.12",
-          "from": "minify@>=2.0.0 <2.1.0",
+          "from": "https://registry.npmjs.org/minify/-/minify-2.0.12.tgz",
           "resolved": "https://registry.npmjs.org/minify/-/minify-2.0.12.tgz",
           "dependencies": {
             "clean-css": {
               "version": "3.4.20",
-              "from": "clean-css@>=3.4.1 <3.5.0",
+              "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz",
               "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
-                  "from": "commander@>=2.8.0 <2.9.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "source-map@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -2893,184 +2910,184 @@
             },
             "css-b64-images": {
               "version": "0.2.5",
-              "from": "css-b64-images@>=0.2.5 <0.3.0",
+              "from": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
               "resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "html-minifier": {
               "version": "3.1.0",
-              "from": "html-minifier@>=3.0.1 <4.0.0",
+              "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.1.0.tgz",
               "dependencies": {
                 "change-case": {
                   "version": "3.0.0",
-                  "from": "change-case@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/change-case/-/change-case-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.0.tgz",
                   "dependencies": {
                     "camel-case": {
                       "version": "3.0.0",
-                      "from": "camel-case@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz"
                     },
                     "constant-case": {
                       "version": "2.0.0",
-                      "from": "constant-case@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz"
                     },
                     "dot-case": {
                       "version": "2.1.0",
-                      "from": "dot-case@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.0.tgz"
                     },
                     "header-case": {
                       "version": "1.0.0",
-                      "from": "header-case@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/header-case/-/header-case-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.0.tgz"
                     },
                     "is-lower-case": {
                       "version": "1.1.3",
-                      "from": "is-lower-case@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
                     },
                     "is-upper-case": {
                       "version": "1.1.2",
-                      "from": "is-upper-case@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
                     },
                     "lower-case": {
                       "version": "1.1.3",
-                      "from": "lower-case@>=1.1.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
                     },
                     "lower-case-first": {
                       "version": "1.0.2",
-                      "from": "lower-case-first@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
                     },
                     "no-case": {
                       "version": "2.3.0",
-                      "from": "no-case@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz"
                     },
                     "param-case": {
                       "version": "2.1.0",
-                      "from": "param-case@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz"
                     },
                     "pascal-case": {
                       "version": "2.0.0",
-                      "from": "pascal-case@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.0.tgz"
                     },
                     "path-case": {
                       "version": "2.1.0",
-                      "from": "path-case@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/path-case/-/path-case-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.0.tgz"
                     },
                     "sentence-case": {
                       "version": "2.1.0",
-                      "from": "sentence-case@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.0.tgz"
                     },
                     "snake-case": {
                       "version": "2.1.0",
-                      "from": "snake-case@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz"
                     },
                     "swap-case": {
                       "version": "1.1.2",
-                      "from": "swap-case@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
                     },
                     "title-case": {
                       "version": "2.1.0",
-                      "from": "title-case@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/title-case/-/title-case-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.0.tgz"
                     },
                     "upper-case": {
                       "version": "1.1.3",
-                      "from": "upper-case@>=1.1.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
                     },
                     "upper-case-first": {
                       "version": "1.1.2",
-                      "from": "upper-case-first@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <2.10.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "he": {
                   "version": "1.1.0",
-                  "from": "he@>=1.1.0 <1.2.0",
+                  "from": "https://registry.npmjs.org/he/-/he-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/he/-/he-1.1.0.tgz"
                 },
                 "ncname": {
                   "version": "1.0.0",
-                  "from": "ncname@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
                   "dependencies": {
                     "xml-char-classes": {
                       "version": "1.0.0",
-                      "from": "xml-char-classes@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
                     }
                   }
                 },
                 "relateurl": {
                   "version": "0.2.7",
-                  "from": "relateurl@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
                   "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
                 }
               }
             },
             "tomas": {
               "version": "1.0.2",
-              "from": "tomas@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/tomas/-/tomas-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/tomas/-/tomas-1.0.2.tgz",
               "dependencies": {
                 "ischanged": {
                   "version": "1.0.17",
-                  "from": "ischanged@>=1.0.7 <1.1.0",
+                  "from": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
                   "resolved": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
                   "dependencies": {
                     "timem": {
                       "version": "1.1.2",
-                      "from": "timem@>=1.1.0 <1.2.0",
+                      "from": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
@@ -3079,110 +3096,110 @@
             },
             "uglify-js": {
               "version": "2.7.3",
-              "from": "uglify-js@>=2.7.0 <3.0.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.5.6",
-                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.3",
-                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.4",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.4",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "1.0.4",
-                              "from": "lazy-cache@>=1.0.3 <2.0.0",
+                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.4",
-                                  "from": "kind-of@>=3.0.2 <4.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.4",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.4",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
                                 }
                               }
@@ -3191,19 +3208,19 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "window-size@0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     }
                   }
@@ -3214,89 +3231,89 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "mollify": {
           "version": "1.0.7",
-          "from": "mollify@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/mollify/-/mollify-1.0.7.tgz",
           "resolved": "https://registry.npmjs.org/mollify/-/mollify-1.0.7.tgz"
         },
         "package-json": {
           "version": "2.3.3",
-          "from": "package-json@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/package-json/-/package-json-2.3.3.tgz",
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.3.tgz",
           "dependencies": {
             "got": {
               "version": "5.6.0",
-              "from": "got@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
               "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
               "dependencies": {
                 "create-error-class": {
                   "version": "3.0.2",
-                  "from": "create-error-class@>=3.0.1 <4.0.0",
+                  "from": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
                   "dependencies": {
                     "capture-stack-trace": {
                       "version": "1.0.0",
-                      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
                     }
                   }
                 },
                 "duplexer2": {
                   "version": "0.1.4",
-                  "from": "duplexer2@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
                 },
                 "is-plain-obj": {
                   "version": "1.1.0",
-                  "from": "is-plain-obj@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                 },
                 "is-redirect": {
                   "version": "1.0.0",
-                  "from": "is-redirect@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                 },
                 "is-retry-allowed": {
                   "version": "1.1.0",
-                  "from": "is-retry-allowed@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
                 },
                 "is-stream": {
                   "version": "1.1.0",
-                  "from": "is-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
                 },
                 "lowercase-keys": {
                   "version": "1.0.0",
-                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                 },
                 "node-status-codes": {
                   "version": "1.0.0",
-                  "from": "node-status-codes@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "parse-json": {
                   "version": "2.2.0",
-                  "from": "parse-json@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                   "dependencies": {
                     "error-ex": {
                       "version": "1.3.0",
-                      "from": "error-ex@>=1.2.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                       "dependencies": {
                         "is-arrayish": {
                           "version": "0.2.1",
-                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                          "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                         }
                       }
@@ -3305,81 +3322,81 @@
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 },
                 "read-all-stream": {
                   "version": "3.1.0",
-                  "from": "read-all-stream@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
                 },
                 "readable-stream": {
                   "version": "2.1.5",
-                  "from": "readable-stream@>=2.0.5 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "timed-out": {
                   "version": "2.0.0",
-                  "from": "timed-out@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                 },
                 "unzip-response": {
                   "version": "1.0.1",
-                  "from": "unzip-response@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz"
                 },
                 "url-parse-lax": {
                   "version": "1.0.0",
-                  "from": "url-parse-lax@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.4",
-                      "from": "prepend-http@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
                     }
                   }
@@ -3388,137 +3405,137 @@
             },
             "rc": {
               "version": "1.1.6",
-              "from": "rc@>=1.1.2 <2.0.0",
+              "from": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
-                  "from": "deep-extend@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "ini@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "strip-json-comments": {
                   "version": "1.0.4",
-                  "from": "strip-json-comments@>=1.0.4 <1.1.0",
+                  "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 }
               }
             },
             "registry-url": {
               "version": "3.1.0",
-              "from": "registry-url@>=3.0.3 <4.0.0",
+              "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
             },
             "semver": {
               "version": "5.3.0",
-              "from": "semver@>=5.1.0 <6.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
             }
           }
         },
         "pipe-io": {
           "version": "1.2.1",
-          "from": "pipe-io@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/pipe-io/-/pipe-io-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/pipe-io/-/pipe-io-1.2.1.tgz"
         },
         "ponse": {
           "version": "1.4.2",
-          "from": "ponse@>=1.4.0 <1.5.0",
+          "from": "https://registry.npmjs.org/ponse/-/ponse-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/ponse/-/ponse-1.4.2.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "extendy": {
               "version": "1.0.1",
-              "from": "extendy@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz"
             },
             "itype": {
               "version": "1.0.2",
-              "from": "itype@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz"
             }
           }
         },
         "readjson": {
           "version": "1.1.3",
-          "from": "readjson@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/readjson/-/readjson-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/readjson/-/readjson-1.1.3.tgz"
         },
         "remedy": {
           "version": "1.3.2",
-          "from": "remedy@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/remedy/-/remedy-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/remedy/-/remedy-1.3.2.tgz",
           "dependencies": {
             "remy": {
               "version": "1.0.5",
-              "from": "remy@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "dependencies": {
                 "findit": {
                   "version": "2.0.0",
-                  "from": "findit@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
                 },
                 "glob": {
                   "version": "7.1.1",
-                  "from": "glob@>=7.1.0 <8.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "inflight": {
-                      "version": "1.0.5",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -3527,26 +3544,26 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.5.4",
-                  "from": "rimraf@>=2.5.0 <2.6.0",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
                 }
               }
@@ -3555,107 +3572,107 @@
         },
         "rendy": {
           "version": "1.1.0",
-          "from": "rendy@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/rendy/-/rendy-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/rendy/-/rendy-1.1.0.tgz"
         },
         "restafary": {
           "version": "1.6.6",
-          "from": "restafary@>=1.6.0 <1.7.0",
+          "from": "https://registry.npmjs.org/restafary/-/restafary-1.6.6.tgz",
           "resolved": "https://registry.npmjs.org/restafary/-/restafary-1.6.6.tgz",
           "dependencies": {
             "ashify": {
               "version": "1.0.1",
-              "from": "ashify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz"
             },
             "beautifile": {
               "version": "1.0.10",
-              "from": "beautifile@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/beautifile/-/beautifile-1.0.10.tgz",
               "resolved": "https://registry.npmjs.org/beautifile/-/beautifile-1.0.10.tgz",
               "dependencies": {
                 "js-beautify": {
                   "version": "1.6.4",
-                  "from": "js-beautify@>=1.6.2 <1.7.0",
+                  "from": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.4.tgz",
                   "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.4.tgz",
                   "dependencies": {
                     "config-chain": {
                       "version": "1.1.11",
-                      "from": "config-chain@>=1.1.5 <1.2.0",
+                      "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
                       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
                       "dependencies": {
                         "proto-list": {
                           "version": "1.2.4",
-                          "from": "proto-list@>=1.2.1 <1.3.0",
+                          "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
                           "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                         },
                         "ini": {
                           "version": "1.3.4",
-                          "from": "ini@>=1.3.4 <2.0.0",
+                          "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
                           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                         }
                       }
                     },
                     "editorconfig": {
                       "version": "0.13.2",
-                      "from": "editorconfig@>=0.13.2 <0.14.0",
+                      "from": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
                       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
                       "dependencies": {
                         "bluebird": {
                           "version": "3.4.6",
-                          "from": "bluebird@>=3.0.5 <4.0.0",
+                          "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
                           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
                         },
                         "commander": {
                           "version": "2.9.0",
-                          "from": "commander@>=2.9.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                           "dependencies": {
                             "graceful-readlink": {
                               "version": "1.0.1",
-                              "from": "graceful-readlink@>=1.0.0",
+                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                             }
                           }
                         },
                         "lru-cache": {
                           "version": "3.2.0",
-                          "from": "lru-cache@>=3.2.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
                           "dependencies": {
                             "pseudomap": {
                               "version": "1.0.2",
-                              "from": "pseudomap@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
                             }
                           }
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "sigmund@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "nopt": {
                       "version": "3.0.6",
-                      "from": "nopt@>=3.0.1 <3.1.0",
+                      "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                       "dependencies": {
                         "abbrev": {
                           "version": "1.0.9",
-                          "from": "abbrev@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
                           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                         }
                       }
@@ -3666,17 +3683,17 @@
             },
             "patchfile": {
               "version": "1.0.7",
-              "from": "patchfile@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "resolved": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "dependencies": {
                 "daffy": {
                   "version": "1.0.3",
-                  "from": "daffy@>=1.0.3 <1.1.0",
+                  "from": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "dependencies": {
                     "diff-match-patch": {
                       "version": "1.0.0",
-                      "from": "diff-match-patch@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz"
                     }
                   }
@@ -3687,100 +3704,100 @@
         },
         "socket.io": {
           "version": "1.4.8",
-          "from": "socket.io@>=1.4.3 <1.5.0",
+          "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz",
           "dependencies": {
             "engine.io": {
               "version": "1.6.11",
-              "from": "engine.io@1.6.11",
+              "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
               "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
               "dependencies": {
                 "base64id": {
                   "version": "0.1.0",
-                  "from": "base64id@0.1.0",
+                  "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
                 },
                 "ws": {
                   "version": "1.1.0",
-                  "from": "ws@1.1.0",
+                  "from": "https://registry.npmjs.org/ws/-/ws-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.0.tgz",
                   "dependencies": {
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     },
                     "ultron": {
                       "version": "1.0.2",
-                      "from": "ultron@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                     }
                   }
                 },
                 "engine.io-parser": {
                   "version": "1.2.4",
-                  "from": "engine.io-parser@1.2.4",
+                  "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                   "dependencies": {
                     "after": {
                       "version": "0.8.1",
-                      "from": "after@0.8.1",
+                      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                     },
                     "arraybuffer.slice": {
                       "version": "0.0.6",
-                      "from": "arraybuffer.slice@0.0.6",
+                      "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                     },
                     "base64-arraybuffer": {
                       "version": "0.1.2",
-                      "from": "base64-arraybuffer@0.1.2",
+                      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                     },
                     "blob": {
                       "version": "0.0.4",
-                      "from": "blob@0.0.4",
+                      "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                     },
                     "has-binary": {
                       "version": "0.1.6",
-                      "from": "has-binary@0.1.6",
+                      "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "dependencies": {
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         }
                       }
                     },
                     "utf8": {
                       "version": "2.1.0",
-                      "from": "utf8@2.1.0",
+                      "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                     }
                   }
                 },
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "accepts@1.1.4",
+                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "mime-db@>=1.12.0 <1.13.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "negotiator@0.4.9",
+                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
@@ -3789,130 +3806,130 @@
             },
             "socket.io-parser": {
               "version": "2.2.6",
-              "from": "socket.io-parser@2.2.6",
+              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
               "dependencies": {
                 "json3": {
                   "version": "3.3.2",
-                  "from": "json3@3.3.2",
+                  "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                 },
                 "component-emitter": {
                   "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "benchmark": {
                   "version": "1.0.0",
-                  "from": "benchmark@1.0.0",
+                  "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                 }
               }
             },
             "socket.io-client": {
               "version": "1.4.8",
-              "from": "socket.io-client@1.4.8",
+              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
               "dependencies": {
                 "engine.io-client": {
                   "version": "1.6.11",
-                  "from": "engine.io-client@1.6.11",
+                  "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
                   "dependencies": {
                     "has-cors": {
                       "version": "1.1.0",
-                      "from": "has-cors@1.1.0",
+                      "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
                     },
                     "ws": {
                       "version": "1.0.1",
-                      "from": "ws@1.0.1",
+                      "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                       "dependencies": {
                         "options": {
                           "version": "0.0.6",
-                          "from": "options@>=0.0.5",
+                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                         },
                         "ultron": {
                           "version": "1.0.2",
-                          "from": "ultron@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                         }
                       }
                     },
                     "xmlhttprequest-ssl": {
                       "version": "1.5.1",
-                      "from": "xmlhttprequest-ssl@1.5.1",
+                      "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "engine.io-parser": {
                       "version": "1.2.4",
-                      "from": "engine.io-parser@1.2.4",
+                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                       "dependencies": {
                         "after": {
                           "version": "0.8.1",
-                          "from": "after@0.8.1",
+                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                           "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                         },
                         "arraybuffer.slice": {
                           "version": "0.0.6",
-                          "from": "arraybuffer.slice@0.0.6",
+                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                           "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                         },
                         "base64-arraybuffer": {
                           "version": "0.1.2",
-                          "from": "base64-arraybuffer@0.1.2",
+                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                         },
                         "blob": {
                           "version": "0.0.4",
-                          "from": "blob@0.0.4",
+                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                         },
                         "has-binary": {
                           "version": "0.1.6",
-                          "from": "has-binary@0.1.6",
+                          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "dependencies": {
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "isarray@0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             }
                           }
                         },
                         "utf8": {
                           "version": "2.1.0",
-                          "from": "utf8@2.1.0",
+                          "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                         }
                       }
                     },
                     "parsejson": {
                       "version": "0.0.1",
-                      "from": "parsejson@0.0.1",
+                      "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "callsite@1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -3921,17 +3938,17 @@
                     },
                     "parseqs": {
                       "version": "0.0.2",
-                      "from": "parseqs@0.0.2",
+                      "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "callsite@1.0.0",
+                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -3940,49 +3957,49 @@
                     },
                     "component-inherit": {
                       "version": "0.0.3",
-                      "from": "component-inherit@0.0.3",
+                      "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
                     },
                     "yeast": {
                       "version": "0.1.2",
-                      "from": "yeast@0.1.2",
+                      "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
                     }
                   }
                 },
                 "component-bind": {
                   "version": "1.0.0",
-                  "from": "component-bind@1.0.0",
+                  "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
                 },
                 "component-emitter": {
                   "version": "1.2.0",
-                  "from": "component-emitter@1.2.0",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
                 },
                 "object-component": {
                   "version": "0.0.3",
-                  "from": "object-component@0.0.3",
+                  "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 },
                 "parseuri": {
                   "version": "0.0.4",
-                  "from": "parseuri@0.0.4",
+                  "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
                           "version": "1.0.0",
-                          "from": "callsite@1.0.0",
+                          "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                         }
                       }
@@ -3991,49 +4008,49 @@
                 },
                 "to-array": {
                   "version": "0.1.4",
-                  "from": "to-array@0.1.4",
+                  "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
                 },
                 "backo2": {
                   "version": "1.0.2",
-                  "from": "backo2@1.0.2",
+                  "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
                 }
               }
             },
             "socket.io-adapter": {
               "version": "0.4.0",
-              "from": "socket.io-adapter@0.4.0",
+              "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
               "dependencies": {
                 "socket.io-parser": {
                   "version": "2.2.2",
-                  "from": "socket.io-parser@2.2.2",
+                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                   "dependencies": {
                     "debug": {
                       "version": "0.7.4",
-                      "from": "debug@0.7.4",
+                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                     },
                     "json3": {
                       "version": "3.2.6",
-                      "from": "json3@3.2.6",
+                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
                       "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "component-emitter@1.1.2",
+                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "benchmark": {
                       "version": "1.0.0",
-                      "from": "benchmark@1.0.0",
+                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                     }
                   }
@@ -4042,24 +4059,24 @@
             },
             "has-binary": {
               "version": "0.1.7",
-              "from": "has-binary@0.1.7",
+              "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
               "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
               "dependencies": {
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "ms@0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
@@ -4068,265 +4085,265 @@
         },
         "spero": {
           "version": "1.3.2",
-          "from": "spero@>=1.3.0 <1.4.0",
+          "from": "https://registry.npmjs.org/spero/-/spero-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/spero/-/spero-1.3.2.tgz"
         },
         "try-catch": {
           "version": "1.0.0",
-          "from": "try-catch@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/try-catch/-/try-catch-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-1.0.0.tgz"
         },
         "tryrequire": {
           "version": "1.1.5",
-          "from": "tryrequire@>=1.1.5 <1.2.0",
+          "from": "https://registry.npmjs.org/tryrequire/-/tryrequire-1.1.5.tgz",
           "resolved": "https://registry.npmjs.org/tryrequire/-/tryrequire-1.1.5.tgz"
         },
         "writejson": {
           "version": "1.1.1",
-          "from": "writejson@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/writejson/-/writejson-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/writejson/-/writejson-1.1.1.tgz"
         }
       }
     },
     "dotenv": {
       "version": "2.0.0",
-      "from": "dotenv@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-2.0.0.tgz"
     },
     "express": {
       "version": "4.14.0",
-      "from": "express@>=4.13.4 <5.0.0",
+      "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.3.3",
-          "from": "accepts@>=1.3.3 <1.4.0",
+          "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "dependencies": {
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
             },
             "negotiator": {
               "version": "0.6.1",
-              "from": "negotiator@0.6.1",
+              "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
             }
           }
         },
         "array-flatten": {
           "version": "1.1.1",
-          "from": "array-flatten@1.1.1",
+          "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
         },
         "content-disposition": {
           "version": "0.5.1",
-          "from": "content-disposition@0.5.1",
+          "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
         },
         "content-type": {
           "version": "1.0.2",
-          "from": "content-type@>=1.0.2 <1.1.0",
+          "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
         },
         "cookie": {
           "version": "0.3.1",
-          "from": "cookie@0.3.1",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "depd": {
           "version": "1.1.0",
-          "from": "depd@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
         },
         "encodeurl": {
           "version": "1.0.1",
-          "from": "encodeurl@>=1.0.1 <1.1.0",
+          "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@>=1.0.3 <1.1.0",
+          "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
         },
         "etag": {
           "version": "1.7.0",
-          "from": "etag@>=1.7.0 <1.8.0",
+          "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
         },
         "finalhandler": {
           "version": "0.5.0",
-          "from": "finalhandler@0.5.0",
+          "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
           "dependencies": {
             "statuses": {
               "version": "1.3.0",
-              "from": "statuses@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             },
             "unpipe": {
               "version": "1.0.0",
-              "from": "unpipe@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
             }
           }
         },
         "fresh": {
           "version": "0.3.0",
-          "from": "fresh@0.3.0",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "from": "merge-descriptors@1.0.1",
+          "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
         },
         "methods": {
           "version": "1.1.2",
-          "from": "methods@>=1.1.2 <1.2.0",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
+          "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "dependencies": {
             "ee-first": {
               "version": "1.1.1",
-              "from": "ee-first@1.1.1",
+              "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
             }
           }
         },
         "parseurl": {
           "version": "1.3.1",
-          "from": "parseurl@>=1.3.1 <1.4.0",
+          "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "from": "path-to-regexp@0.1.7",
+          "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
         },
         "proxy-addr": {
           "version": "1.1.2",
-          "from": "proxy-addr@>=1.1.2 <1.2.0",
+          "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
           "dependencies": {
             "forwarded": {
               "version": "0.1.0",
-              "from": "forwarded@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
             },
             "ipaddr.js": {
               "version": "1.1.1",
-              "from": "ipaddr.js@1.1.1",
+              "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
             }
           }
         },
         "qs": {
           "version": "6.2.0",
-          "from": "qs@6.2.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "range-parser": {
           "version": "1.2.0",
-          "from": "range-parser@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
         },
         "send": {
           "version": "0.14.1",
-          "from": "send@0.14.1",
+          "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
           "dependencies": {
             "destroy": {
               "version": "1.0.4",
-              "from": "destroy@>=1.0.4 <1.1.0",
+              "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
             },
             "http-errors": {
               "version": "1.5.0",
-              "from": "http-errors@>=1.5.0 <1.6.0",
+              "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "setprototypeof": {
                   "version": "1.0.1",
-                  "from": "setprototypeof@1.0.1",
+                  "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                 }
               }
             },
             "mime": {
               "version": "1.3.4",
-              "from": "mime@1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
             },
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             },
             "statuses": {
               "version": "1.3.0",
-              "from": "statuses@>=1.3.0 <1.4.0",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
             }
           }
         },
         "serve-static": {
           "version": "1.11.1",
-          "from": "serve-static@>=1.11.1 <1.12.0",
+          "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
         },
         "type-is": {
           "version": "1.6.13",
-          "from": "type-is@>=1.6.13 <1.7.0",
+          "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
           "dependencies": {
             "media-typer": {
               "version": "0.3.0",
-              "from": "media-typer@0.3.0",
+              "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.11 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                 }
               }
@@ -4335,117 +4352,117 @@
         },
         "utils-merge": {
           "version": "1.0.0",
-          "from": "utils-merge@1.0.0",
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         },
         "vary": {
           "version": "1.1.0",
-          "from": "vary@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
         }
       }
     },
     "os-homedir": {
       "version": "1.0.2",
-      "from": "os-homedir@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "socket.io": {
       "version": "1.5.0",
-      "from": "socket.io@>=1.4.5 <2.0.0",
+      "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.0.tgz",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.0.tgz",
       "dependencies": {
         "engine.io": {
           "version": "1.7.0",
-          "from": "engine.io@1.7.0",
+          "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.0.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.3.3",
-              "from": "accepts@1.3.3",
+              "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.1.12",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "from": "mime-db@>=1.24.0 <1.25.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
                 },
                 "negotiator": {
                   "version": "0.6.1",
-                  "from": "negotiator@0.6.1",
+                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                 }
               }
             },
             "base64id": {
               "version": "0.1.0",
-              "from": "base64id@0.1.0",
+              "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "engine.io-parser": {
               "version": "1.3.0",
-              "from": "engine.io-parser@1.3.0",
+              "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
               "dependencies": {
                 "after": {
                   "version": "0.8.1",
-                  "from": "after@0.8.1",
+                  "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                   "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                 },
                 "arraybuffer.slice": {
                   "version": "0.0.6",
-                  "from": "arraybuffer.slice@0.0.6",
+                  "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                 },
                 "base64-arraybuffer": {
                   "version": "0.1.5",
-                  "from": "base64-arraybuffer@0.1.5",
+                  "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz"
                 },
                 "blob": {
                   "version": "0.0.4",
-                  "from": "blob@0.0.4",
+                  "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                 },
                 "has-binary": {
                   "version": "0.1.6",
-                  "from": "has-binary@0.1.6",
+                  "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                   "dependencies": {
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     }
                   }
                 },
                 "wtf-8": {
                   "version": "1.0.0",
-                  "from": "wtf-8@1.0.0",
+                  "from": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
                 }
               }
             },
             "ws": {
               "version": "1.1.1",
-              "from": "ws@1.1.1",
+              "from": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
               "dependencies": {
                 "options": {
                   "version": "0.0.6",
-                  "from": "options@>=0.0.5",
+                  "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                 },
                 "ultron": {
                   "version": "1.0.2",
-                  "from": "ultron@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                 }
               }
@@ -4454,113 +4471,113 @@
         },
         "socket.io-parser": {
           "version": "2.2.6",
-          "from": "socket.io-parser@2.2.6",
+          "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
           "dependencies": {
             "json3": {
               "version": "3.3.2",
-              "from": "json3@3.3.2",
+              "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
               "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
             },
             "component-emitter": {
               "version": "1.1.2",
-              "from": "component-emitter@1.1.2",
+              "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "benchmark": {
               "version": "1.0.0",
-              "from": "benchmark@1.0.0",
+              "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
             }
           }
         },
         "socket.io-client": {
           "version": "1.5.0",
-          "from": "socket.io-client@1.5.0",
+          "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.0.tgz",
           "dependencies": {
             "engine.io-client": {
               "version": "1.7.0",
-              "from": "engine.io-client@1.7.0",
+              "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.0.tgz",
               "dependencies": {
                 "component-emitter": {
                   "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                 },
                 "component-inherit": {
                   "version": "0.0.3",
-                  "from": "component-inherit@0.0.3",
+                  "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
                 },
                 "engine.io-parser": {
                   "version": "1.3.0",
-                  "from": "engine.io-parser@1.3.0",
+                  "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
                   "dependencies": {
                     "after": {
                       "version": "0.8.1",
-                      "from": "after@0.8.1",
+                      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                     },
                     "arraybuffer.slice": {
                       "version": "0.0.6",
-                      "from": "arraybuffer.slice@0.0.6",
+                      "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                     },
                     "base64-arraybuffer": {
                       "version": "0.1.5",
-                      "from": "base64-arraybuffer@0.1.5",
+                      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz"
                     },
                     "blob": {
                       "version": "0.0.4",
-                      "from": "blob@0.0.4",
+                      "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                     },
                     "has-binary": {
                       "version": "0.1.6",
-                      "from": "has-binary@0.1.6",
+                      "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "dependencies": {
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         }
                       }
                     },
                     "wtf-8": {
                       "version": "1.0.0",
-                      "from": "wtf-8@1.0.0",
+                      "from": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
                     }
                   }
                 },
                 "has-cors": {
                   "version": "1.1.0",
-                  "from": "has-cors@1.1.0",
+                  "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
                 },
                 "parsejson": {
                   "version": "0.0.1",
-                  "from": "parsejson@0.0.1",
+                  "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
                           "version": "1.0.0",
-                          "from": "callsite@1.0.0",
+                          "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                         }
                       }
@@ -4569,17 +4586,17 @@
                 },
                 "parseqs": {
                   "version": "0.0.2",
-                  "from": "parseqs@0.0.2",
+                  "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
                           "version": "1.0.0",
-                          "from": "callsite@1.0.0",
+                          "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                         }
                       }
@@ -4588,66 +4605,66 @@
                 },
                 "ws": {
                   "version": "1.1.1",
-                  "from": "ws@1.1.1",
+                  "from": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                   "dependencies": {
                     "options": {
                       "version": "0.0.6",
-                      "from": "options@>=0.0.5",
+                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     },
                     "ultron": {
                       "version": "1.0.2",
-                      "from": "ultron@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                     }
                   }
                 },
                 "xmlhttprequest-ssl": {
                   "version": "1.5.1",
-                  "from": "xmlhttprequest-ssl@1.5.1",
+                  "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
                 },
                 "yeast": {
                   "version": "0.1.2",
-                  "from": "yeast@0.1.2",
+                  "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
                 }
               }
             },
             "component-bind": {
               "version": "1.0.0",
-              "from": "component-bind@1.0.0",
+              "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
             },
             "component-emitter": {
               "version": "1.2.0",
-              "from": "component-emitter@1.2.0",
+              "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
             },
             "object-component": {
               "version": "0.0.3",
-              "from": "object-component@0.0.3",
+              "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
             },
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
+              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             },
             "parseuri": {
               "version": "0.0.4",
-              "from": "parseuri@0.0.4",
+              "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
               "dependencies": {
                 "better-assert": {
                   "version": "1.0.2",
-                  "from": "better-assert@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                   "dependencies": {
                     "callsite": {
                       "version": "1.0.0",
-                      "from": "callsite@1.0.0",
+                      "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                     }
                   }
@@ -4656,49 +4673,49 @@
             },
             "to-array": {
               "version": "0.1.4",
-              "from": "to-array@0.1.4",
+              "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
             },
             "backo2": {
               "version": "1.0.2",
-              "from": "backo2@1.0.2",
+              "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
             }
           }
         },
         "socket.io-adapter": {
           "version": "0.4.0",
-          "from": "socket.io-adapter@0.4.0",
+          "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
           "dependencies": {
             "socket.io-parser": {
               "version": "2.2.2",
-              "from": "socket.io-parser@2.2.2",
+              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
               "dependencies": {
                 "debug": {
                   "version": "0.7.4",
-                  "from": "debug@0.7.4",
+                  "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                 },
                 "json3": {
                   "version": "3.2.6",
-                  "from": "json3@3.2.6",
+                  "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
                   "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                 },
                 "component-emitter": {
                   "version": "1.1.2",
-                  "from": "component-emitter@1.1.2",
+                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "benchmark": {
                   "version": "1.0.0",
-                  "from": "benchmark@1.0.0",
+                  "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                 }
               }
@@ -4707,24 +4724,24 @@
         },
         "has-binary": {
           "version": "0.1.7",
-          "from": "has-binary@0.1.7",
+          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -283,299 +283,299 @@
     },
     "cloudcmd": {
       "version": "5.3.1",
-      "from": "git://github.com/OSC/cloudcmd.git#f71a76acfa432019b1cb1dc3f6ade6e49c6d2027",
-      "resolved": "git://github.com/OSC/cloudcmd.git#f71a76acfa432019b1cb1dc3f6ade6e49c6d2027",
+      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.20",
+      "resolved": "git://github.com/OSC/cloudcmd.git#cddcbf74391917d2d32fa1786424c164a2c8c7b2",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "from": "chalk@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.2.1",
-              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "from": "supports-color@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "checkup": {
           "version": "1.3.0",
-          "from": "https://registry.npmjs.org/checkup/-/checkup-1.3.0.tgz",
+          "from": "checkup@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/checkup/-/checkup-1.3.0.tgz"
         },
         "console-io": {
-          "version": "2.7.10",
-          "from": "https://registry.npmjs.org/console-io/-/console-io-2.7.10.tgz",
-          "resolved": "https://registry.npmjs.org/console-io/-/console-io-2.7.10.tgz",
+          "version": "2.7.13",
+          "from": "console-io@>=2.7.1 <2.8.0",
+          "resolved": "https://registry.npmjs.org/console-io/-/console-io-2.7.13.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "express": {
               "version": "4.14.0",
-              "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+              "from": "express@>=4.14.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                  "from": "accepts@>=1.3.3 <1.4.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                      "from": "negotiator@0.6.1",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
                 "array-flatten": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                  "from": "array-flatten@1.1.1",
                   "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
                 },
                 "content-disposition": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+                  "from": "content-disposition@0.5.1",
                   "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
                 },
                 "content-type": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+                  "from": "content-type@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
                 },
                 "cookie": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                  "from": "cookie@0.3.1",
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
                 },
                 "cookie-signature": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                  "from": "cookie-signature@1.0.6",
                   "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 },
                 "depd": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                  "from": "depd@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 },
                 "encodeurl": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+                  "from": "encodeurl@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
                 },
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                  "from": "escape-html@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "etag": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                  "from": "etag@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "finalhandler": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+                  "from": "finalhandler@0.5.0",
                   "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "dependencies": {
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                      "from": "statuses@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                      "from": "unpipe@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                     }
                   }
                 },
                 "fresh": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                  "from": "fresh@0.3.0",
                   "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
                 },
                 "merge-descriptors": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+                  "from": "merge-descriptors@1.0.1",
                   "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
                 },
                 "methods": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+                  "from": "methods@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                      "from": "ee-first@1.1.1",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "parseurl": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+                  "from": "parseurl@>=1.3.1 <1.4.0",
                   "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
                 },
                 "path-to-regexp": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                  "from": "path-to-regexp@0.1.7",
                   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
                 },
                 "proxy-addr": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+                  "from": "proxy-addr@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "dependencies": {
                     "forwarded": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+                      "from": "forwarded@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                     },
                     "ipaddr.js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+                      "from": "ipaddr.js@1.1.1",
                       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "6.2.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+                  "from": "qs@6.2.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                 },
                 "range-parser": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                  "from": "range-parser@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
                 },
                 "send": {
                   "version": "0.14.1",
-                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                  "from": "send@0.14.1",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                      "from": "destroy@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.5.0",
-                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                      "from": "http-errors@>=1.5.0 <1.6.0",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "setprototypeof": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+                          "from": "setprototypeof@1.0.1",
                           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                      "from": "mime@1.3.4",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                      "from": "statuses@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     }
                   }
                 },
                 "serve-static": {
                   "version": "1.11.1",
-                  "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+                  "from": "serve-static@>=1.11.1 <1.12.0",
                   "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
                 },
                 "type-is": {
                   "version": "1.6.13",
-                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+                  "from": "type-is@>=1.6.13 <1.7.0",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "dependencies": {
                     "media-typer": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                      "from": "media-typer@0.3.0",
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
@@ -584,112 +584,112 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "from": "utils-merge@1.0.0",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 },
                 "vary": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+                  "from": "vary@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
                 }
               }
             },
             "socket.io": {
-              "version": "1.5.0",
-              "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.0.tgz",
-              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.0.tgz",
+              "version": "1.5.1",
+              "from": "socket.io@>=1.5.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.5.1.tgz",
               "dependencies": {
                 "engine.io": {
-                  "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.0.tgz",
+                  "version": "1.7.2",
+                  "from": "engine.io@1.7.2",
+                  "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.7.2.tgz",
                   "dependencies": {
                     "accepts": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                      "from": "accepts@1.3.3",
                       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                       "dependencies": {
                         "mime-types": {
                           "version": "2.1.12",
-                          "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                          "from": "mime-types@>=2.1.11 <2.2.0",
                           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                           "dependencies": {
                             "mime-db": {
                               "version": "1.24.0",
-                              "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                              "from": "mime-db@>=1.24.0 <1.25.0",
                               "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                             }
                           }
                         },
                         "negotiator": {
                           "version": "0.6.1",
-                          "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                          "from": "negotiator@0.6.1",
                           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                         }
                       }
                     },
                     "base64id": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+                      "from": "base64id@0.1.0",
                       "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
                     },
                     "engine.io-parser": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
+                      "version": "1.3.1",
+                      "from": "engine.io-parser@1.3.1",
+                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
                       "dependencies": {
                         "after": {
                           "version": "0.8.1",
-                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+                          "from": "after@0.8.1",
                           "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                         },
                         "arraybuffer.slice": {
                           "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+                          "from": "arraybuffer.slice@0.0.6",
                           "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                         },
                         "base64-arraybuffer": {
                           "version": "0.1.5",
-                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+                          "from": "base64-arraybuffer@0.1.5",
                           "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz"
                         },
                         "blob": {
                           "version": "0.0.4",
-                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+                          "from": "blob@0.0.4",
                           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                         },
                         "has-binary": {
                           "version": "0.1.6",
-                          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                          "from": "has-binary@0.1.6",
                           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "dependencies": {
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             }
                           }
                         },
                         "wtf-8": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+                          "from": "wtf-8@1.0.0",
                           "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
                         }
                       }
                     },
                     "ws": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+                      "from": "ws@1.1.1",
                       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                       "dependencies": {
                         "options": {
                           "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                          "from": "options@>=0.0.5",
                           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                         },
                         "ultron": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                          "from": "ultron@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                         }
                       }
@@ -697,114 +697,109 @@
                   }
                 },
                 "socket.io-parser": {
-                  "version": "2.2.6",
-                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
-                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
+                  "version": "2.3.1",
+                  "from": "socket.io-parser@2.3.1",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
                   "dependencies": {
                     "json3": {
                       "version": "3.3.2",
-                      "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+                      "from": "json3@3.3.2",
                       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                      "from": "component-emitter@1.1.2",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "benchmark": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                     }
                   }
                 },
                 "socket.io-client": {
-                  "version": "1.5.0",
-                  "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.0.tgz",
-                  "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.0.tgz",
+                  "version": "1.5.1",
+                  "from": "socket.io-client@1.5.1",
+                  "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.5.1.tgz",
                   "dependencies": {
                     "engine.io-client": {
-                      "version": "1.7.0",
-                      "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.0.tgz",
-                      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.0.tgz",
+                      "version": "1.7.2",
+                      "from": "engine.io-client@1.7.2",
+                      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.7.2.tgz",
                       "dependencies": {
                         "component-emitter": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                          "from": "component-emitter@1.1.2",
                           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                         },
                         "component-inherit": {
                           "version": "0.0.3",
-                          "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+                          "from": "component-inherit@0.0.3",
                           "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
                         },
                         "engine.io-parser": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.0.tgz",
+                          "version": "1.3.1",
+                          "from": "engine.io-parser@1.3.1",
+                          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.1.tgz",
                           "dependencies": {
                             "after": {
                               "version": "0.8.1",
-                              "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+                              "from": "after@0.8.1",
                               "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                             },
                             "arraybuffer.slice": {
                               "version": "0.0.6",
-                              "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+                              "from": "arraybuffer.slice@0.0.6",
                               "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                             },
                             "base64-arraybuffer": {
                               "version": "0.1.5",
-                              "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+                              "from": "base64-arraybuffer@0.1.5",
                               "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz"
                             },
                             "blob": {
                               "version": "0.0.4",
-                              "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+                              "from": "blob@0.0.4",
                               "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                             },
                             "has-binary": {
                               "version": "0.1.6",
-                              "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                              "from": "has-binary@0.1.6",
                               "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                               "dependencies": {
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "from": "isarray@0.0.1",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 }
                               }
                             },
                             "wtf-8": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+                              "from": "wtf-8@1.0.0",
                               "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz"
                             }
                           }
                         },
                         "has-cors": {
                           "version": "1.1.0",
-                          "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+                          "from": "has-cors@1.1.0",
                           "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
                         },
                         "parsejson": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                          "from": "parsejson@0.0.1",
                           "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                           "dependencies": {
                             "better-assert": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "from": "better-assert@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                               "dependencies": {
                                 "callsite": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                                  "from": "callsite@1.0.0",
                                   "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                                 }
                               }
@@ -813,17 +808,17 @@
                         },
                         "parseqs": {
                           "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                          "from": "parseqs@0.0.2",
                           "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                           "dependencies": {
                             "better-assert": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                              "from": "better-assert@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                               "dependencies": {
                                 "callsite": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                                  "from": "callsite@1.0.0",
                                   "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                                 }
                               }
@@ -832,66 +827,66 @@
                         },
                         "ws": {
                           "version": "1.1.1",
-                          "from": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+                          "from": "ws@1.1.1",
                           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
                           "dependencies": {
                             "options": {
                               "version": "0.0.6",
-                              "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                              "from": "options@>=0.0.5",
                               "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                             },
                             "ultron": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                              "from": "ultron@>=1.0.0 <1.1.0",
                               "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                             }
                           }
                         },
                         "xmlhttprequest-ssl": {
                           "version": "1.5.1",
-                          "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
+                          "from": "xmlhttprequest-ssl@1.5.1",
                           "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
                         },
                         "yeast": {
                           "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+                          "from": "yeast@0.1.2",
                           "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
                         }
                       }
                     },
                     "component-bind": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+                      "from": "component-bind@1.0.0",
                       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
                     },
                     "component-emitter": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
+                      "from": "component-emitter@1.2.0",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
                     },
                     "object-component": {
                       "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+                      "from": "object-component@0.0.3",
                       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
                     },
                     "indexof": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                      "from": "indexof@0.0.1",
                       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                     },
                     "parseuri": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                      "from": "parseuri@0.0.4",
                       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                              "from": "callsite@1.0.0",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -900,49 +895,49 @@
                     },
                     "to-array": {
                       "version": "0.1.4",
-                      "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+                      "from": "to-array@0.1.4",
                       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
                     },
                     "backo2": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+                      "from": "backo2@1.0.2",
                       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
                     }
                   }
                 },
                 "socket.io-adapter": {
                   "version": "0.4.0",
-                  "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
+                  "from": "socket.io-adapter@0.4.0",
                   "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
                   "dependencies": {
                     "socket.io-parser": {
                       "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                      "from": "socket.io-parser@2.2.2",
                       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                       "dependencies": {
                         "debug": {
                           "version": "0.7.4",
-                          "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                          "from": "debug@0.7.4",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                         },
                         "json3": {
                           "version": "3.2.6",
-                          "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+                          "from": "json3@3.2.6",
                           "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                         },
                         "component-emitter": {
                           "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                          "from": "component-emitter@1.1.2",
                           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "benchmark": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+                          "from": "benchmark@1.0.0",
                           "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                         }
                       }
@@ -951,12 +946,12 @@
                 },
                 "has-binary": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+                  "from": "has-binary@0.1.7",
                   "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
                   "dependencies": {
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     }
                   }
@@ -965,54 +960,54 @@
             },
             "spawnify": {
               "version": "2.3.4",
-              "from": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
+              "from": "spawnify@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
               "dependencies": {
                 "glob": {
                   "version": "7.1.1",
-                  "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "from": "glob@>=7.1.0 <8.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                      "from": "fs.realpath@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "from": "minimatch@>=3.0.2 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -1021,109 +1016,109 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
                 },
                 "untildify": {
                   "version": "2.1.0",
-                  "from": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+                  "from": "untildify@>=2.1.0 <2.2.0",
                   "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
                 },
                 "win32": {
                   "version": "0.9.11",
-                  "from": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz",
+                  "from": "win32@>=0.9.4 <0.10.0",
                   "resolved": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz"
                 }
               }
             },
             "tildify": {
               "version": "1.2.0",
-              "from": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+              "from": "tildify@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
             }
           }
         },
         "copymitter": {
           "version": "1.8.10",
-          "from": "https://registry.npmjs.org/copymitter/-/copymitter-1.8.10.tgz",
+          "from": "copymitter@>=1.8.0 <1.9.0",
           "resolved": "https://registry.npmjs.org/copymitter/-/copymitter-1.8.10.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "findit": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
+              "from": "findit@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
             },
             "glob": {
               "version": "7.1.1",
-              "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+              "from": "glob@>=7.1.0 <8.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "from": "minimatch@>=3.0.2 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "from": "balanced-match@>=0.4.1 <0.5.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -1132,19 +1127,19 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 }
               }
@@ -1153,253 +1148,253 @@
         },
         "criton": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/criton/-/criton-1.0.0.tgz",
+          "from": "criton@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/criton/-/criton-1.0.0.tgz"
         },
         "dword": {
           "version": "3.0.16",
-          "from": "https://registry.npmjs.org/dword/-/dword-3.0.16.tgz",
+          "from": "dword@>=3.0.3 <3.1.0",
           "resolved": "https://registry.npmjs.org/dword/-/dword-3.0.16.tgz",
           "dependencies": {
             "ashify": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz",
+              "from": "ashify@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz"
             },
             "express": {
               "version": "4.14.0",
-              "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+              "from": "express@>=4.14.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                  "from": "accepts@>=1.3.3 <1.4.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                      "from": "negotiator@0.6.1",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
                 "array-flatten": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                  "from": "array-flatten@1.1.1",
                   "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
                 },
                 "content-disposition": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+                  "from": "content-disposition@0.5.1",
                   "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
                 },
                 "content-type": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+                  "from": "content-type@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
                 },
                 "cookie": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                  "from": "cookie@0.3.1",
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
                 },
                 "cookie-signature": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                  "from": "cookie-signature@1.0.6",
                   "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "from": "debug@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "depd": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                  "from": "depd@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 },
                 "encodeurl": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+                  "from": "encodeurl@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
                 },
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                  "from": "escape-html@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "etag": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                  "from": "etag@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "finalhandler": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+                  "from": "finalhandler@0.5.0",
                   "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "dependencies": {
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                      "from": "statuses@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                      "from": "unpipe@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                     }
                   }
                 },
                 "fresh": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                  "from": "fresh@0.3.0",
                   "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
                 },
                 "merge-descriptors": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+                  "from": "merge-descriptors@1.0.1",
                   "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
                 },
                 "methods": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+                  "from": "methods@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                      "from": "ee-first@1.1.1",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "parseurl": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+                  "from": "parseurl@>=1.3.1 <1.4.0",
                   "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
                 },
                 "path-to-regexp": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                  "from": "path-to-regexp@0.1.7",
                   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
                 },
                 "proxy-addr": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+                  "from": "proxy-addr@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "dependencies": {
                     "forwarded": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+                      "from": "forwarded@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                     },
                     "ipaddr.js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+                      "from": "ipaddr.js@1.1.1",
                       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "6.2.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+                  "from": "qs@6.2.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                 },
                 "range-parser": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                  "from": "range-parser@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
                 },
                 "send": {
                   "version": "0.14.1",
-                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                  "from": "send@0.14.1",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                      "from": "destroy@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.5.0",
-                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                      "from": "http-errors@>=1.5.0 <1.6.0",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "setprototypeof": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+                          "from": "setprototypeof@1.0.1",
                           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                      "from": "mime@1.3.4",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                      "from": "statuses@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     }
                   }
                 },
                 "serve-static": {
                   "version": "1.11.1",
-                  "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+                  "from": "serve-static@>=1.11.1 <1.12.0",
                   "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
                 },
                 "type-is": {
                   "version": "1.6.13",
-                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+                  "from": "type-is@>=1.6.13 <1.7.0",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "dependencies": {
                     "media-typer": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                      "from": "media-typer@0.3.0",
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
@@ -1408,29 +1403,29 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "from": "utils-merge@1.0.0",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 },
                 "vary": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+                  "from": "vary@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
                 }
               }
             },
             "patchfile": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
+              "from": "patchfile@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "dependencies": {
                 "daffy": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
+                  "from": "daffy@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "dependencies": {
                     "diff-match-patch": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+                      "from": "diff-match-patch@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz"
                     }
                   }
@@ -1439,255 +1434,255 @@
             },
             "socket-file": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz",
+              "from": "socket-file@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz"
             }
           }
         },
         "edward": {
           "version": "3.0.7",
-          "from": "https://registry.npmjs.org/edward/-/edward-3.0.7.tgz",
+          "from": "edward@>=3.0.0 <3.1.0",
           "resolved": "https://registry.npmjs.org/edward/-/edward-3.0.7.tgz",
           "dependencies": {
             "ashify": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz",
+              "from": "ashify@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz"
             },
             "express": {
               "version": "4.14.0",
-              "from": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
+              "from": "express@>=4.14.0 <5.0.0",
               "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.3.3",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                  "from": "accepts@>=1.3.3 <1.4.0",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.6.1",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+                      "from": "negotiator@0.6.1",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
                 "array-flatten": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+                  "from": "array-flatten@1.1.1",
                   "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
                 },
                 "content-disposition": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+                  "from": "content-disposition@0.5.1",
                   "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
                 },
                 "content-type": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+                  "from": "content-type@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
                 },
                 "cookie": {
                   "version": "0.3.1",
-                  "from": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+                  "from": "cookie@0.3.1",
                   "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
                 },
                 "cookie-signature": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+                  "from": "cookie-signature@1.0.6",
                   "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
                 },
                 "debug": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "from": "debug@>=2.2.0 <2.3.0",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     }
                   }
                 },
                 "depd": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+                  "from": "depd@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
                 },
                 "encodeurl": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+                  "from": "encodeurl@>=1.0.1 <1.1.0",
                   "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
                 },
                 "escape-html": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+                  "from": "escape-html@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
                 },
                 "etag": {
                   "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+                  "from": "etag@>=1.7.0 <1.8.0",
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "finalhandler": {
                   "version": "0.5.0",
-                  "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
+                  "from": "finalhandler@0.5.0",
                   "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
                   "dependencies": {
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                      "from": "statuses@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                      "from": "unpipe@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                     }
                   }
                 },
                 "fresh": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+                  "from": "fresh@0.3.0",
                   "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
                 },
                 "merge-descriptors": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+                  "from": "merge-descriptors@1.0.1",
                   "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
                 },
                 "methods": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+                  "from": "methods@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.3.0",
-                  "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
                   "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                      "from": "ee-first@1.1.1",
                       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
                 "parseurl": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+                  "from": "parseurl@>=1.3.1 <1.4.0",
                   "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
                 },
                 "path-to-regexp": {
                   "version": "0.1.7",
-                  "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+                  "from": "path-to-regexp@0.1.7",
                   "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
                 },
                 "proxy-addr": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
+                  "from": "proxy-addr@>=1.1.2 <1.2.0",
                   "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz",
                   "dependencies": {
                     "forwarded": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+                      "from": "forwarded@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                     },
                     "ipaddr.js": {
                       "version": "1.1.1",
-                      "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz",
+                      "from": "ipaddr.js@1.1.1",
                       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
                     }
                   }
                 },
                 "qs": {
                   "version": "6.2.0",
-                  "from": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
+                  "from": "qs@6.2.0",
                   "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
                 },
                 "range-parser": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+                  "from": "range-parser@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
                 },
                 "send": {
                   "version": "0.14.1",
-                  "from": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
+                  "from": "send@0.14.1",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                      "from": "destroy@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.5.0",
-                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
+                      "from": "http-errors@>=1.5.0 <1.6.0",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "from": "inherits@2.0.1",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "setprototypeof": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz",
+                          "from": "setprototypeof@1.0.1",
                           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                      "from": "mime@1.3.4",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz",
+                      "from": "statuses@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.0.tgz"
                     }
                   }
                 },
                 "serve-static": {
                   "version": "1.11.1",
-                  "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz",
+                  "from": "serve-static@>=1.11.1 <1.12.0",
                   "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
                 },
                 "type-is": {
                   "version": "1.6.13",
-                  "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+                  "from": "type-is@>=1.6.13 <1.7.0",
                   "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
                   "dependencies": {
                     "media-typer": {
                       "version": "0.3.0",
-                      "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                      "from": "media-typer@0.3.0",
                       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                     },
                     "mime-types": {
                       "version": "2.1.12",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.24.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                          "from": "mime-db@>=1.24.0 <1.25.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                         }
                       }
@@ -1696,29 +1691,29 @@
                 },
                 "utils-merge": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+                  "from": "utils-merge@1.0.0",
                   "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 },
                 "vary": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
+                  "from": "vary@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
                 }
               }
             },
             "patchfile": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
+              "from": "patchfile@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "dependencies": {
                 "daffy": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
+                  "from": "daffy@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "dependencies": {
                     "diff-match-patch": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+                      "from": "diff-match-patch@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz"
                     }
                   }
@@ -1727,252 +1722,252 @@
             },
             "socket-file": {
               "version": "1.2.1",
-              "from": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz",
+              "from": "socket-file@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/socket-file/-/socket-file-1.2.1.tgz"
             }
           }
         },
         "execon": {
           "version": "1.2.9",
-          "from": "https://registry.npmjs.org/execon/-/execon-1.2.9.tgz",
+          "from": "execon@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/execon/-/execon-1.2.9.tgz"
         },
         "express": {
           "version": "4.13.4",
-          "from": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
+          "from": "express@>=4.13.0 <4.14.0",
           "resolved": "https://registry.npmjs.org/express/-/express-4.13.4.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.2.13",
-              "from": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+              "from": "accepts@>=1.2.12 <1.3.0",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
               "dependencies": {
                 "mime-types": {
                   "version": "2.1.12",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "from": "mime-types@>=2.1.6 <2.2.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                      "from": "mime-db@>=1.24.0 <1.25.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
                 },
                 "negotiator": {
                   "version": "0.5.3",
-                  "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
+                  "from": "negotiator@0.5.3",
                   "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
                 }
               }
             },
             "array-flatten": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+              "from": "array-flatten@1.1.1",
               "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
             },
             "content-disposition": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz",
+              "from": "content-disposition@0.5.1",
               "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
             },
             "content-type": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+              "from": "content-type@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
             },
             "cookie": {
               "version": "0.1.5",
-              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz",
+              "from": "cookie@0.1.5",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.5.tgz"
             },
             "cookie-signature": {
               "version": "1.0.6",
-              "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+              "from": "cookie-signature@1.0.6",
               "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "depd": {
               "version": "1.1.0",
-              "from": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "from": "depd@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
             },
             "escape-html": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+              "from": "escape-html@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
             },
             "etag": {
               "version": "1.7.0",
-              "from": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz",
+              "from": "etag@>=1.7.0 <1.8.0",
               "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
             },
             "finalhandler": {
               "version": "0.4.1",
-              "from": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
+              "from": "finalhandler@0.4.1",
               "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.4.1.tgz",
               "dependencies": {
                 "unpipe": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
                 }
               }
             },
             "fresh": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
+              "from": "fresh@0.3.0",
               "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
             },
             "merge-descriptors": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+              "from": "merge-descriptors@1.0.1",
               "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
             },
             "methods": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+              "from": "methods@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
             },
             "on-finished": {
               "version": "2.3.0",
-              "from": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "from": "on-finished@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
               "dependencies": {
                 "ee-first": {
                   "version": "1.1.1",
-                  "from": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+                  "from": "ee-first@1.1.1",
                   "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                 }
               }
             },
             "parseurl": {
               "version": "1.3.1",
-              "from": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+              "from": "parseurl@>=1.3.1 <1.4.0",
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
             },
             "path-to-regexp": {
               "version": "0.1.7",
-              "from": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+              "from": "path-to-regexp@0.1.7",
               "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
             },
             "proxy-addr": {
               "version": "1.0.10",
-              "from": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
+              "from": "proxy-addr@>=1.0.10 <1.1.0",
               "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.10.tgz",
               "dependencies": {
                 "forwarded": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+                  "from": "forwarded@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
                 },
                 "ipaddr.js": {
                   "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
+                  "from": "ipaddr.js@1.0.5",
                   "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz"
                 }
               }
             },
             "qs": {
               "version": "4.0.0",
-              "from": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+              "from": "qs@4.0.0",
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "range-parser": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz",
+              "from": "range-parser@>=1.0.3 <1.1.0",
               "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
             },
             "send": {
               "version": "0.13.1",
-              "from": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
+              "from": "send@0.13.1",
               "resolved": "https://registry.npmjs.org/send/-/send-0.13.1.tgz",
               "dependencies": {
                 "destroy": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                  "from": "destroy@>=1.0.4 <1.1.0",
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                 },
                 "http-errors": {
                   "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                  "from": "http-errors@>=1.3.1 <1.4.0",
                   "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     }
                   }
                 },
                 "mime": {
                   "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                  "from": "mime@1.3.4",
                   "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                 },
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                  "from": "statuses@>=1.2.1 <1.3.0",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "serve-static": {
               "version": "1.10.3",
-              "from": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
+              "from": "serve-static@>=1.10.2 <1.11.0",
               "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.3.tgz",
               "dependencies": {
                 "send": {
                   "version": "0.13.2",
-                  "from": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
+                  "from": "send@0.13.2",
                   "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
                   "dependencies": {
                     "destroy": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+                      "from": "destroy@>=1.0.4 <1.1.0",
                       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
                     },
                     "http-errors": {
                       "version": "1.3.1",
-                      "from": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                      "from": "http-errors@>=1.3.1 <1.4.0",
                       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
                       "dependencies": {
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         }
                       }
                     },
                     "mime": {
                       "version": "1.3.4",
-                      "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+                      "from": "mime@1.3.4",
                       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
                     },
                     "ms": {
                       "version": "0.7.1",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                      "from": "ms@0.7.1",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                     },
                     "statuses": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                      "from": "statuses@>=1.2.1 <1.3.0",
                       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                     }
                   }
@@ -1981,22 +1976,22 @@
             },
             "type-is": {
               "version": "1.6.13",
-              "from": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
+              "from": "type-is@>=1.6.6 <1.7.0",
               "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+                  "from": "media-typer@0.3.0",
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
                   "version": "2.1.12",
-                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+                  "from": "mime-types@>=2.1.6 <2.2.0",
                   "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
                   "dependencies": {
                     "mime-db": {
                       "version": "1.24.0",
-                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                      "from": "mime-db@>=1.24.0 <1.25.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
                     }
                   }
@@ -2005,29 +2000,29 @@
             },
             "utils-merge": {
               "version": "1.0.0",
-              "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+              "from": "utils-merge@1.0.0",
               "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             },
             "vary": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz",
+              "from": "vary@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
             }
           }
         },
         "faust": {
           "version": "1.0.4",
-          "from": "https://registry.npmjs.org/faust/-/faust-1.0.4.tgz",
+          "from": "faust@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/faust/-/faust-1.0.4.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
@@ -2036,78 +2031,78 @@
         },
         "files-io": {
           "version": "1.2.6",
-          "from": "https://registry.npmjs.org/files-io/-/files-io-1.2.6.tgz",
+          "from": "files-io@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/files-io/-/files-io-1.2.6.tgz",
           "dependencies": {
             "extendy": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz",
+              "from": "extendy@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz"
             },
             "itype": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz",
+              "from": "itype@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz"
             }
           }
         },
         "flop": {
           "version": "1.4.2",
-          "from": "https://registry.npmjs.org/flop/-/flop-1.4.2.tgz",
+          "from": "flop@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/flop/-/flop-1.4.2.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                  "from": "minimist@0.0.8",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "readify": {
-              "version": "3.0.0",
-              "from": "https://registry.npmjs.org/readify/-/readify-3.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/readify/-/readify-3.0.0.tgz",
+              "version": "3.1.0",
+              "from": "readify@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/readify/-/readify-3.1.0.tgz",
               "dependencies": {
                 "currify": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/currify/-/currify-1.0.0.tgz",
+                  "from": "currify@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/currify/-/currify-1.0.0.tgz"
                 },
                 "es6-promisify": {
                   "version": "5.0.0",
-                  "from": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+                  "from": "es6-promisify@>=5.0.0 <6.0.0",
                   "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
                   "dependencies": {
                     "es6-promise": {
                       "version": "4.0.5",
-                      "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
+                      "from": "es6-promise@>=4.0.3 <5.0.0",
                       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz"
                     }
                   }
                 },
                 "nicki": {
                   "version": "1.2.11",
-                  "from": "https://registry.npmjs.org/nicki/-/nicki-1.2.11.tgz",
+                  "from": "nicki@>=1.2.2 <1.3.0",
                   "resolved": "https://registry.npmjs.org/nicki/-/nicki-1.2.11.tgz",
                   "dependencies": {
                     "ischanged": {
                       "version": "1.0.17",
-                      "from": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
+                      "from": "ischanged@>=1.0.2 <1.1.0",
                       "resolved": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
                       "dependencies": {
                         "debug": {
                           "version": "2.2.0",
-                          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "from": "debug@>=2.2.0 <2.3.0",
                           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                           "dependencies": {
                             "ms": {
                               "version": "0.7.1",
-                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                              "from": "ms@0.7.1",
                               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                             }
                           }
@@ -2116,54 +2111,54 @@
                     },
                     "spawnify": {
                       "version": "2.3.4",
-                      "from": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
+                      "from": "spawnify@>=2.3.0 <2.4.0",
                       "resolved": "https://registry.npmjs.org/spawnify/-/spawnify-2.3.4.tgz",
                       "dependencies": {
                         "glob": {
                           "version": "7.1.1",
-                          "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                          "from": "glob@>=7.1.0 <8.0.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                           "dependencies": {
                             "fs.realpath": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                              "from": "fs.realpath@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                             },
                             "inflight": {
                               "version": "1.0.6",
-                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                              "from": "inflight@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.3",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                              "from": "inherits@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                             },
                             "minimatch": {
                               "version": "3.0.3",
-                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                              "from": "minimatch@>=3.0.2 <4.0.0",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.6",
-                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.4.2",
-                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                                      "from": "balanced-match@>=0.4.1 <0.5.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "from": "concat-map@0.0.1",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                     }
                                   }
@@ -2172,31 +2167,31 @@
                             },
                             "once": {
                               "version": "1.4.0",
-                              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                              "from": "once@>=1.3.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                             }
                           }
                         },
                         "tildify": {
                           "version": "1.2.0",
-                          "from": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+                          "from": "tildify@>=1.2.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz"
                         },
                         "untildify": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
+                          "from": "untildify@>=2.1.0 <2.2.0",
                           "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz"
                         }
                       }
@@ -2205,71 +2200,71 @@
                 },
                 "shortdate": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/shortdate/-/shortdate-1.2.0.tgz",
+                  "from": "shortdate@>=1.2.0 <1.3.0",
                   "resolved": "https://registry.npmjs.org/shortdate/-/shortdate-1.2.0.tgz"
                 },
                 "squad": {
                   "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/squad/-/squad-1.1.3.tgz",
+                  "from": "squad@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/squad/-/squad-1.1.3.tgz"
                 }
               }
             },
             "remy": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
+              "from": "remy@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "dependencies": {
                 "findit": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
+                  "from": "findit@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
                 },
                 "glob": {
                   "version": "7.1.1",
-                  "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "from": "glob@>=7.1.0 <8.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                      "from": "fs.realpath@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "from": "minimatch@>=3.0.2 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -2278,196 +2273,196 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.5.4",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+                  "from": "rimraf@>=2.5.0 <2.6.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
                 }
               }
             },
             "timem": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz",
+              "from": "timem@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz"
             },
             "trammel": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/trammel/-/trammel-1.0.2.tgz",
+              "from": "trammel@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/trammel/-/trammel-1.0.2.tgz"
             },
             "win32": {
               "version": "0.9.11",
-              "from": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz",
+              "from": "win32@>=0.9.10 <0.10.0",
               "resolved": "https://registry.npmjs.org/win32/-/win32-0.9.11.tgz"
             }
           }
         },
         "format-io": {
           "version": "0.9.6",
-          "from": "https://registry.npmjs.org/format-io/-/format-io-0.9.6.tgz",
+          "from": "format-io@>=0.9.6 <0.10.0",
           "resolved": "https://registry.npmjs.org/format-io/-/format-io-0.9.6.tgz"
         },
         "freeport": {
           "version": "1.0.5",
-          "from": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
+          "from": "freeport@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz"
         },
         "http-auth": {
           "version": "2.2.9",
-          "from": "https://registry.npmjs.org/http-auth/-/http-auth-2.2.9.tgz",
+          "from": "http-auth@>=2.2.3 <2.3.0",
           "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-2.2.9.tgz",
           "dependencies": {
             "node-uuid": {
               "version": "1.4.1",
-              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz",
+              "from": "node-uuid@1.4.1",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
             },
             "htpasswd": {
               "version": "2.2.2",
-              "from": "https://registry.npmjs.org/htpasswd/-/htpasswd-2.2.2.tgz",
+              "from": "htpasswd@2.2.2",
               "resolved": "https://registry.npmjs.org/htpasswd/-/htpasswd-2.2.2.tgz",
               "dependencies": {
                 "apache-md5": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.0.4.tgz",
+                  "from": "apache-md5@1.0.4",
                   "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.0.4.tgz"
                 },
                 "commander": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz",
+                  "from": "commander@2.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.0.0.tgz"
                 },
                 "prompt": {
                   "version": "0.2.11",
-                  "from": "https://registry.npmjs.org/prompt/-/prompt-0.2.11.tgz",
+                  "from": "prompt@0.2.11",
                   "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.11.tgz",
                   "dependencies": {
                     "pkginfo": {
                       "version": "0.4.0",
-                      "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
+                      "from": "pkginfo@>=0.0.0 <1.0.0",
                       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz"
                     },
                     "read": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+                      "from": "read@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
                       "dependencies": {
                         "mute-stream": {
                           "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
+                          "from": "mute-stream@>=0.0.4 <0.1.0",
                           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz"
                         }
                       }
                     },
                     "revalidator": {
                       "version": "0.1.8",
-                      "from": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+                      "from": "revalidator@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
                     },
                     "utile": {
                       "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+                      "from": "utile@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.2.10",
-                          "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                          "from": "async@>=0.2.9 <0.3.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                         },
                         "deep-equal": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+                          "from": "deep-equal@*",
                           "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz"
                         },
                         "i": {
                           "version": "0.3.5",
-                          "from": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
+                          "from": "i@>=0.3.0 <0.4.0",
                           "resolved": "https://registry.npmjs.org/i/-/i-0.3.5.tgz"
                         },
                         "mkdirp": {
                           "version": "0.5.1",
-                          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "from": "mkdirp@>=0.0.0 <1.0.0",
                           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                           "dependencies": {
                             "minimist": {
                               "version": "0.0.8",
-                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                              "from": "minimist@0.0.8",
                               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                             }
                           }
                         },
                         "ncp": {
                           "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+                          "from": "ncp@>=0.4.0 <0.5.0",
                           "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
                         },
                         "rimraf": {
                           "version": "2.5.4",
-                          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+                          "from": "rimraf@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
                           "dependencies": {
                             "glob": {
                               "version": "7.1.1",
-                              "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                              "from": "glob@>=7.0.5 <8.0.0",
                               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                               "dependencies": {
                                 "fs.realpath": {
                                   "version": "1.0.0",
-                                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                                  "from": "fs.realpath@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                                 },
                                 "inflight": {
                                   "version": "1.0.6",
-                                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                                  "from": "inflight@>=1.0.4 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "inherits": {
                                   "version": "2.0.3",
-                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                                  "from": "inherits@>=2.0.0 <3.0.0",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                                 },
                                 "minimatch": {
                                   "version": "3.0.3",
-                                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                                  "from": "minimatch@>=3.0.2 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                                   "dependencies": {
                                     "brace-expansion": {
                                       "version": "1.1.6",
-                                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                       "dependencies": {
                                         "balanced-match": {
                                           "version": "0.4.2",
-                                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                                          "from": "balanced-match@>=0.4.1 <0.5.0",
                                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                         },
                                         "concat-map": {
                                           "version": "0.0.1",
-                                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                          "from": "concat-map@0.0.1",
                                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                         }
                                       }
@@ -2476,19 +2471,19 @@
                                 },
                                 "once": {
                                   "version": "1.4.0",
-                                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                                  "from": "once@>=1.3.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                                   "dependencies": {
                                     "wrappy": {
                                       "version": "1.0.2",
-                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                      "from": "wrappy@>=1.0.0 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                                     }
                                   }
                                 },
                                 "path-is-absolute": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                                 }
                               }
@@ -2499,42 +2494,42 @@
                     },
                     "winston": {
                       "version": "0.6.2",
-                      "from": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
+                      "from": "winston@>=0.6.0 <0.7.0",
                       "resolved": "https://registry.npmjs.org/winston/-/winston-0.6.2.tgz",
                       "dependencies": {
                         "async": {
                           "version": "0.1.22",
-                          "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
+                          "from": "async@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
                         },
                         "colors": {
                           "version": "0.6.2",
-                          "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+                          "from": "colors@>=0.0.0 <1.0.0",
                           "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
                         },
                         "cycle": {
                           "version": "1.0.3",
-                          "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+                          "from": "cycle@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
                         },
                         "eyes": {
                           "version": "0.1.8",
-                          "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+                          "from": "eyes@>=0.1.0 <0.2.0",
                           "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
                         },
                         "pkginfo": {
                           "version": "0.2.3",
-                          "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+                          "from": "pkginfo@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz"
                         },
                         "request": {
                           "version": "2.9.203",
-                          "from": "https://registry.npmjs.org/request/-/request-2.9.203.tgz",
+                          "from": "request@>=2.9.0 <2.10.0",
                           "resolved": "https://registry.npmjs.org/request/-/request-2.9.203.tgz"
                         },
                         "stack-trace": {
                           "version": "0.0.9",
-                          "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+                          "from": "stack-trace@>=0.0.0 <0.1.0",
                           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
                         }
                       }
@@ -2543,12 +2538,12 @@
                 },
                 "apache-crypt": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.1.0.tgz",
+                  "from": "apache-crypt@1.1.0",
                   "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.1.0.tgz",
                   "dependencies": {
                     "unix-crypt-td-js": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz",
+                      "from": "unix-crypt-td-js@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz"
                     }
                   }
@@ -2559,64 +2554,64 @@
         },
         "ishtar": {
           "version": "1.3.5",
-          "from": "https://registry.npmjs.org/ishtar/-/ishtar-1.3.5.tgz",
+          "from": "ishtar@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/ishtar/-/ishtar-1.3.5.tgz"
         },
         "jaguar": {
           "version": "1.1.13",
-          "from": "https://registry.npmjs.org/jaguar/-/jaguar-1.1.13.tgz",
+          "from": "jaguar@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/jaguar/-/jaguar-1.1.13.tgz",
           "dependencies": {
             "findit": {
               "version": "2.0.0",
-              "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
+              "from": "findit@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
             },
             "glob": {
               "version": "7.1.1",
-              "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+              "from": "glob@>=7.1.0 <8.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
               "dependencies": {
                 "fs.realpath": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                  "from": "fs.realpath@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                 },
                 "inflight": {
                   "version": "1.0.6",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                  "from": "minimatch@>=3.0.2 <4.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                          "from": "balanced-match@>=0.4.1 <0.5.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -2625,58 +2620,58 @@
                 },
                 "once": {
                   "version": "1.4.0",
-                  "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "from": "once@>=1.3.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 }
               }
             },
             "tar-fs": {
               "version": "1.14.0",
-              "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.14.0.tgz",
+              "from": "tar-fs@>=1.13.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.14.0.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "pump": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
+                  "from": "pump@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "from": "end-of-stream@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.3",
-                          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "from": "once@>=1.3.0 <1.4.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
@@ -2685,12 +2680,12 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "from": "once@>=1.3.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
@@ -2701,47 +2696,47 @@
             },
             "tar-stream": {
               "version": "1.5.2",
-              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
+              "from": "tar-stream@>=1.5.1 <1.6.0",
               "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
               "dependencies": {
                 "bl": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                  "from": "bl@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "2.0.6",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                      "from": "readable-stream@>=2.0.5 <2.1.0",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "from": "inherits@>=2.0.1 <2.1.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                          "from": "isarray@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
@@ -2750,17 +2745,17 @@
                 },
                 "end-of-stream": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "from": "end-of-stream@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
@@ -2769,49 +2764,49 @@
                 },
                 "readable-stream": {
                   "version": "2.1.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "from": "readable-stream@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "from": "isarray@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                  "from": "xtend@>=4.0.0 <5.0.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
@@ -2820,88 +2815,88 @@
         },
         "join-io": {
           "version": "1.4.4",
-          "from": "https://registry.npmjs.org/join-io/-/join-io-1.4.4.tgz",
+          "from": "join-io@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/join-io/-/join-io-1.4.4.tgz"
         },
         "jonny": {
           "version": "1.0.1",
-          "from": "https://registry.npmjs.org/jonny/-/jonny-1.0.1.tgz",
+          "from": "jonny@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/jonny/-/jonny-1.0.1.tgz"
         },
         "markdown-it": {
           "version": "6.0.5",
-          "from": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.0.5.tgz",
+          "from": "markdown-it@>=6.0.0 <6.1.0",
           "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-6.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "1.0.9",
-              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "from": "argparse@>=1.0.7 <2.0.0",
               "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
               "dependencies": {
                 "sprintf-js": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                 }
               }
             },
             "entities": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+              "from": "entities@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
             },
             "linkify-it": {
               "version": "1.2.4",
-              "from": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz",
+              "from": "linkify-it@>=1.2.2 <1.3.0",
               "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-1.2.4.tgz"
             },
             "mdurl": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+              "from": "mdurl@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz"
             },
             "uc.micro": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
+              "from": "uc.micro@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz"
             }
           }
         },
         "mellow": {
           "version": "2.0.2",
-          "from": "https://registry.npmjs.org/mellow/-/mellow-2.0.2.tgz",
+          "from": "mellow@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/mellow/-/mellow-2.0.2.tgz"
         },
         "minify": {
           "version": "2.0.12",
-          "from": "https://registry.npmjs.org/minify/-/minify-2.0.12.tgz",
+          "from": "minify@>=2.0.0 <2.1.0",
           "resolved": "https://registry.npmjs.org/minify/-/minify-2.0.12.tgz",
           "dependencies": {
             "clean-css": {
               "version": "3.4.20",
-              "from": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz",
+              "from": "clean-css@>=3.4.1 <3.5.0",
               "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.20.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.8.1",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "from": "commander@>=2.8.0 <2.9.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.4.4",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "from": "source-map@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                   "dependencies": {
                     "amdefine": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
+                      "from": "amdefine@>=0.0.4",
                       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                     }
                   }
@@ -2910,184 +2905,184 @@
             },
             "css-b64-images": {
               "version": "0.2.5",
-              "from": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz",
+              "from": "css-b64-images@>=0.2.5 <0.3.0",
               "resolved": "https://registry.npmjs.org/css-b64-images/-/css-b64-images-0.2.5.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "html-minifier": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.1.0.tgz",
+              "from": "html-minifier@>=3.0.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.1.0.tgz",
               "dependencies": {
                 "change-case": {
                   "version": "3.0.0",
-                  "from": "https://registry.npmjs.org/change-case/-/change-case-3.0.0.tgz",
+                  "from": "change-case@>=3.0.0 <3.1.0",
                   "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.0.0.tgz",
                   "dependencies": {
                     "camel-case": {
                       "version": "3.0.0",
-                      "from": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+                      "from": "camel-case@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz"
                     },
                     "constant-case": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+                      "from": "constant-case@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz"
                     },
                     "dot-case": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.0.tgz",
+                      "from": "dot-case@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.0.tgz"
                     },
                     "header-case": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/header-case/-/header-case-1.0.0.tgz",
+                      "from": "header-case@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.0.tgz"
                     },
                     "is-lower-case": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+                      "from": "is-lower-case@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz"
                     },
                     "is-upper-case": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+                      "from": "is-upper-case@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz"
                     },
                     "lower-case": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz",
+                      "from": "lower-case@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.3.tgz"
                     },
                     "lower-case-first": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+                      "from": "lower-case-first@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz"
                     },
                     "no-case": {
                       "version": "2.3.0",
-                      "from": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz",
+                      "from": "no-case@>=2.2.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.0.tgz"
                     },
                     "param-case": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz",
+                      "from": "param-case@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.0.tgz"
                     },
                     "pascal-case": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.0.tgz",
+                      "from": "pascal-case@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.0.tgz"
                     },
                     "path-case": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/path-case/-/path-case-2.1.0.tgz",
+                      "from": "path-case@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.0.tgz"
                     },
                     "sentence-case": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.0.tgz",
+                      "from": "sentence-case@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.0.tgz"
                     },
                     "snake-case": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+                      "from": "snake-case@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz"
                     },
                     "swap-case": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+                      "from": "swap-case@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz"
                     },
                     "title-case": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/title-case/-/title-case-2.1.0.tgz",
+                      "from": "title-case@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.0.tgz"
                     },
                     "upper-case": {
                       "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+                      "from": "upper-case@>=1.1.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
                     },
                     "upper-case-first": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+                      "from": "upper-case-first@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "from": "commander@>=2.9.0 <2.10.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "from": "graceful-readlink@>=1.0.0",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "he": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/he/-/he-1.1.0.tgz",
+                  "from": "he@>=1.1.0 <1.2.0",
                   "resolved": "https://registry.npmjs.org/he/-/he-1.1.0.tgz"
                 },
                 "ncname": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+                  "from": "ncname@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
                   "dependencies": {
                     "xml-char-classes": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
+                      "from": "xml-char-classes@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
                     }
                   }
                 },
                 "relateurl": {
                   "version": "0.2.7",
-                  "from": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+                  "from": "relateurl@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
                 }
               }
             },
             "tomas": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/tomas/-/tomas-1.0.2.tgz",
+              "from": "tomas@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/tomas/-/tomas-1.0.2.tgz",
               "dependencies": {
                 "ischanged": {
                   "version": "1.0.17",
-                  "from": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
+                  "from": "ischanged@>=1.0.7 <1.1.0",
                   "resolved": "https://registry.npmjs.org/ischanged/-/ischanged-1.0.17.tgz",
                   "dependencies": {
                     "timem": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz",
+                      "from": "timem@>=1.1.0 <1.2.0",
                       "resolved": "https://registry.npmjs.org/timem/-/timem-1.1.2.tgz"
                     }
                   }
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
@@ -3095,112 +3090,112 @@
               }
             },
             "uglify-js": {
-              "version": "2.7.3",
-              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.3.tgz",
+              "version": "2.7.4",
+              "from": "uglify-js@>=2.7.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.4.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "from": "async@>=0.2.6 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.5.6",
-                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                  "from": "source-map@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "from": "yargs@>=3.10.0 <3.11.0",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "from": "cliui@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                          "from": "center-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.4",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.4",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.4",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                  "version": "1.6.1",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "1.0.4",
-                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                              "from": "lazy-cache@>=1.0.3 <2.0.0",
                               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "from": "right-align@>=0.1.1 <0.2.0",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.4",
-                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "3.0.4",
-                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                                  "from": "kind-of@>=3.0.2 <4.0.0",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.4",
-                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                  "from": "longest@>=1.0.1 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
-                                  "version": "1.5.4",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.4.tgz"
+                                  "version": "1.6.1",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
                                 }
                               }
                             }
@@ -3208,19 +3203,19 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "from": "wordwrap@0.0.2",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                      "from": "window-size@0.1.0",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     }
                   }
@@ -3231,89 +3226,89 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "from": "minimist@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "mollify": {
           "version": "1.0.7",
-          "from": "https://registry.npmjs.org/mollify/-/mollify-1.0.7.tgz",
+          "from": "mollify@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/mollify/-/mollify-1.0.7.tgz"
         },
         "package-json": {
           "version": "2.3.3",
-          "from": "https://registry.npmjs.org/package-json/-/package-json-2.3.3.tgz",
+          "from": "package-json@>=2.3.0 <2.4.0",
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.3.3.tgz",
           "dependencies": {
             "got": {
               "version": "5.6.0",
-              "from": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
+              "from": "got@>=5.0.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
               "dependencies": {
                 "create-error-class": {
                   "version": "3.0.2",
-                  "from": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+                  "from": "create-error-class@>=3.0.1 <4.0.0",
                   "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
                   "dependencies": {
                     "capture-stack-trace": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                      "from": "capture-stack-trace@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz"
                     }
                   }
                 },
                 "duplexer2": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+                  "from": "duplexer2@>=0.1.4 <0.2.0",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
                 },
                 "is-plain-obj": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                  "from": "is-plain-obj@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                 },
                 "is-redirect": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+                  "from": "is-redirect@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz"
                 },
                 "is-retry-allowed": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                  "from": "is-retry-allowed@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz"
                 },
                 "is-stream": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+                  "from": "is-stream@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
                 },
                 "lowercase-keys": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                  "from": "lowercase-keys@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
                 },
                 "node-status-codes": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+                  "from": "node-status-codes@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz"
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
                 },
                 "parse-json": {
                   "version": "2.2.0",
-                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                  "from": "parse-json@>=2.1.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                   "dependencies": {
                     "error-ex": {
                       "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                      "from": "error-ex@>=1.2.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                       "dependencies": {
                         "is-arrayish": {
                           "version": "0.2.1",
-                          "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                          "from": "is-arrayish@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                         }
                       }
@@ -3322,81 +3317,81 @@
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "from": "pinkie@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 },
                 "read-all-stream": {
                   "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+                  "from": "read-all-stream@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz"
                 },
                 "readable-stream": {
                   "version": "2.1.5",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "from": "readable-stream@>=2.0.5 <3.0.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "from": "isarray@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 },
                 "timed-out": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+                  "from": "timed-out@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
                 },
                 "unzip-response": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz",
+                  "from": "unzip-response@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.1.tgz"
                 },
                 "url-parse-lax": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                  "from": "url-parse-lax@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.4",
-                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                      "from": "prepend-http@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
                     }
                   }
@@ -3405,137 +3400,137 @@
             },
             "rc": {
               "version": "1.1.6",
-              "from": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+              "from": "rc@>=1.1.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
               "dependencies": {
                 "deep-extend": {
                   "version": "0.4.1",
-                  "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+                  "from": "deep-extend@>=0.4.0 <0.5.0",
                   "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
                 },
                 "ini": {
                   "version": "1.3.4",
-                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                  "from": "ini@>=1.3.0 <1.4.0",
                   "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                 },
                 "strip-json-comments": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+                  "from": "strip-json-comments@>=1.0.4 <1.1.0",
                   "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
                 }
               }
             },
             "registry-url": {
               "version": "3.1.0",
-              "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+              "from": "registry-url@>=3.0.3 <4.0.0",
               "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz"
             },
             "semver": {
               "version": "5.3.0",
-              "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "from": "semver@>=5.1.0 <6.0.0",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
             }
           }
         },
         "pipe-io": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/pipe-io/-/pipe-io-1.2.1.tgz",
+          "from": "pipe-io@>=1.2.0 <1.3.0",
           "resolved": "https://registry.npmjs.org/pipe-io/-/pipe-io-1.2.1.tgz"
         },
         "ponse": {
           "version": "1.4.2",
-          "from": "https://registry.npmjs.org/ponse/-/ponse-1.4.2.tgz",
+          "from": "ponse@>=1.4.0 <1.5.0",
           "resolved": "https://registry.npmjs.org/ponse/-/ponse-1.4.2.tgz",
           "dependencies": {
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
             },
             "extendy": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz",
+              "from": "extendy@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/extendy/-/extendy-1.0.1.tgz"
             },
             "itype": {
               "version": "1.0.2",
-              "from": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz",
+              "from": "itype@>=1.0.1 <1.1.0",
               "resolved": "https://registry.npmjs.org/itype/-/itype-1.0.2.tgz"
             }
           }
         },
         "readjson": {
           "version": "1.1.3",
-          "from": "https://registry.npmjs.org/readjson/-/readjson-1.1.3.tgz",
+          "from": "readjson@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/readjson/-/readjson-1.1.3.tgz"
         },
         "remedy": {
           "version": "1.3.2",
-          "from": "https://registry.npmjs.org/remedy/-/remedy-1.3.2.tgz",
+          "from": "remedy@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/remedy/-/remedy-1.3.2.tgz",
           "dependencies": {
             "remy": {
               "version": "1.0.5",
-              "from": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
+              "from": "remy@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/remy/-/remy-1.0.5.tgz",
               "dependencies": {
                 "findit": {
                   "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz",
+                  "from": "findit@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/findit/-/findit-2.0.0.tgz"
                 },
                 "glob": {
                   "version": "7.1.1",
-                  "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                  "from": "glob@>=7.1.0 <8.0.0",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                   "dependencies": {
                     "fs.realpath": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                      "from": "fs.realpath@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
                     },
                     "inflight": {
                       "version": "1.0.6",
-                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                      "from": "inflight@>=1.0.4 <2.0.0",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "from": "inherits@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                      "from": "minimatch@>=3.0.2 <4.0.0",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.6",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                              "from": "balanced-match@>=0.4.1 <0.5.0",
                               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "from": "concat-map@0.0.1",
                               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -3544,26 +3539,26 @@
                     },
                     "once": {
                       "version": "1.4.0",
-                      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                      "from": "once@>=1.3.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
                     },
                     "path-is-absolute": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                     }
                   }
                 },
                 "rimraf": {
                   "version": "2.5.4",
-                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+                  "from": "rimraf@>=2.5.0 <2.6.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
                 }
               }
@@ -3572,107 +3567,107 @@
         },
         "rendy": {
           "version": "1.1.0",
-          "from": "https://registry.npmjs.org/rendy/-/rendy-1.1.0.tgz",
+          "from": "rendy@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/rendy/-/rendy-1.1.0.tgz"
         },
         "restafary": {
           "version": "1.6.6",
-          "from": "https://registry.npmjs.org/restafary/-/restafary-1.6.6.tgz",
+          "from": "restafary@>=1.6.0 <1.7.0",
           "resolved": "https://registry.npmjs.org/restafary/-/restafary-1.6.6.tgz",
           "dependencies": {
             "ashify": {
               "version": "1.0.1",
-              "from": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz",
+              "from": "ashify@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/ashify/-/ashify-1.0.1.tgz"
             },
             "beautifile": {
               "version": "1.0.10",
-              "from": "https://registry.npmjs.org/beautifile/-/beautifile-1.0.10.tgz",
+              "from": "beautifile@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/beautifile/-/beautifile-1.0.10.tgz",
               "dependencies": {
                 "js-beautify": {
                   "version": "1.6.4",
-                  "from": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.4.tgz",
+                  "from": "js-beautify@>=1.6.2 <1.7.0",
                   "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.6.4.tgz",
                   "dependencies": {
                     "config-chain": {
                       "version": "1.1.11",
-                      "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+                      "from": "config-chain@>=1.1.5 <1.2.0",
                       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
                       "dependencies": {
                         "proto-list": {
                           "version": "1.2.4",
-                          "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                          "from": "proto-list@>=1.2.1 <1.3.0",
                           "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
                         },
                         "ini": {
                           "version": "1.3.4",
-                          "from": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+                          "from": "ini@>=1.3.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
                         }
                       }
                     },
                     "editorconfig": {
                       "version": "0.13.2",
-                      "from": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
+                      "from": "editorconfig@>=0.13.2 <0.14.0",
                       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.2.tgz",
                       "dependencies": {
                         "bluebird": {
                           "version": "3.4.6",
-                          "from": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz",
+                          "from": "bluebird@>=3.0.5 <4.0.0",
                           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.6.tgz"
                         },
                         "commander": {
                           "version": "2.9.0",
-                          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "from": "commander@>=2.9.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                           "dependencies": {
                             "graceful-readlink": {
                               "version": "1.0.1",
-                              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                              "from": "graceful-readlink@>=1.0.0",
                               "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                             }
                           }
                         },
                         "lru-cache": {
                           "version": "3.2.0",
-                          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+                          "from": "lru-cache@>=3.2.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
                           "dependencies": {
                             "pseudomap": {
                               "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+                              "from": "pseudomap@>=1.0.1 <2.0.0",
                               "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
                             }
                           }
                         },
                         "sigmund": {
                           "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                          "from": "sigmund@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                         }
                       }
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "nopt": {
                       "version": "3.0.6",
-                      "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                      "from": "nopt@>=3.0.1 <3.1.0",
                       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                       "dependencies": {
                         "abbrev": {
                           "version": "1.0.9",
-                          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                          "from": "abbrev@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
                         }
                       }
@@ -3683,17 +3678,17 @@
             },
             "patchfile": {
               "version": "1.0.7",
-              "from": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
+              "from": "patchfile@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/patchfile/-/patchfile-1.0.7.tgz",
               "dependencies": {
                 "daffy": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
+                  "from": "daffy@>=1.0.3 <1.1.0",
                   "resolved": "https://registry.npmjs.org/daffy/-/daffy-1.0.3.tgz",
                   "dependencies": {
                     "diff-match-patch": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+                      "from": "diff-match-patch@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz"
                     }
                   }
@@ -3704,100 +3699,100 @@
         },
         "socket.io": {
           "version": "1.4.8",
-          "from": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz",
+          "from": "socket.io@>=1.4.3 <1.5.0",
           "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.4.8.tgz",
           "dependencies": {
             "engine.io": {
               "version": "1.6.11",
-              "from": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
+              "from": "engine.io@1.6.11",
               "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.6.11.tgz",
               "dependencies": {
                 "base64id": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+                  "from": "base64id@0.1.0",
                   "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
                 },
                 "ws": {
                   "version": "1.1.0",
-                  "from": "https://registry.npmjs.org/ws/-/ws-1.1.0.tgz",
+                  "from": "ws@1.1.0",
                   "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.0.tgz",
                   "dependencies": {
                     "options": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                      "from": "options@>=0.0.5",
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     },
                     "ultron": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                      "from": "ultron@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                     }
                   }
                 },
                 "engine.io-parser": {
                   "version": "1.2.4",
-                  "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
+                  "from": "engine.io-parser@1.2.4",
                   "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                   "dependencies": {
                     "after": {
                       "version": "0.8.1",
-                      "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+                      "from": "after@0.8.1",
                       "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                     },
                     "arraybuffer.slice": {
                       "version": "0.0.6",
-                      "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+                      "from": "arraybuffer.slice@0.0.6",
                       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                     },
                     "base64-arraybuffer": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
+                      "from": "base64-arraybuffer@0.1.2",
                       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                     },
                     "blob": {
                       "version": "0.0.4",
-                      "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+                      "from": "blob@0.0.4",
                       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                     },
                     "has-binary": {
                       "version": "0.1.6",
-                      "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                      "from": "has-binary@0.1.6",
                       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                       "dependencies": {
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "from": "isarray@0.0.1",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         }
                       }
                     },
                     "utf8": {
                       "version": "2.1.0",
-                      "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
+                      "from": "utf8@2.1.0",
                       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                     }
                   }
                 },
                 "accepts": {
                   "version": "1.1.4",
-                  "from": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "from": "accepts@1.1.4",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
                   "dependencies": {
                     "mime-types": {
                       "version": "2.0.14",
-                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
                       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
                       "dependencies": {
                         "mime-db": {
                           "version": "1.12.0",
-                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+                          "from": "mime-db@>=1.12.0 <1.13.0",
                           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
                       "version": "0.4.9",
-                      "from": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz",
+                      "from": "negotiator@0.4.9",
                       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
                     }
                   }
@@ -3806,130 +3801,130 @@
             },
             "socket.io-parser": {
               "version": "2.2.6",
-              "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
+              "from": "socket.io-parser@2.2.6",
               "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.6.tgz",
               "dependencies": {
                 "json3": {
                   "version": "3.3.2",
-                  "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+                  "from": "json3@3.3.2",
                   "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
                 },
                 "component-emitter": {
                   "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                  "from": "component-emitter@1.1.2",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "benchmark": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+                  "from": "benchmark@1.0.0",
                   "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                 }
               }
             },
             "socket.io-client": {
               "version": "1.4.8",
-              "from": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
+              "from": "socket.io-client@1.4.8",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.4.8.tgz",
               "dependencies": {
                 "engine.io-client": {
                   "version": "1.6.11",
-                  "from": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
+                  "from": "engine.io-client@1.6.11",
                   "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.6.11.tgz",
                   "dependencies": {
                     "has-cors": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+                      "from": "has-cors@1.1.0",
                       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz"
                     },
                     "ws": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
+                      "from": "ws@1.0.1",
                       "resolved": "https://registry.npmjs.org/ws/-/ws-1.0.1.tgz",
                       "dependencies": {
                         "options": {
                           "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                          "from": "options@>=0.0.5",
                           "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                         },
                         "ultron": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                          "from": "ultron@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                         }
                       }
                     },
                     "xmlhttprequest-ssl": {
                       "version": "1.5.1",
-                      "from": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz",
+                      "from": "xmlhttprequest-ssl@1.5.1",
                       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.1.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                      "from": "component-emitter@1.1.2",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "engine.io-parser": {
                       "version": "1.2.4",
-                      "from": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
+                      "from": "engine.io-parser@1.2.4",
                       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.4.tgz",
                       "dependencies": {
                         "after": {
                           "version": "0.8.1",
-                          "from": "https://registry.npmjs.org/after/-/after-0.8.1.tgz",
+                          "from": "after@0.8.1",
                           "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
                         },
                         "arraybuffer.slice": {
                           "version": "0.0.6",
-                          "from": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+                          "from": "arraybuffer.slice@0.0.6",
                           "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
                         },
                         "base64-arraybuffer": {
                           "version": "0.1.2",
-                          "from": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz",
+                          "from": "base64-arraybuffer@0.1.2",
                           "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
                         },
                         "blob": {
                           "version": "0.0.4",
-                          "from": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+                          "from": "blob@0.0.4",
                           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz"
                         },
                         "has-binary": {
                           "version": "0.1.6",
-                          "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                          "from": "has-binary@0.1.6",
                           "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
                           "dependencies": {
                             "isarray": {
                               "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "from": "isarray@0.0.1",
                               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                             }
                           }
                         },
                         "utf8": {
                           "version": "2.1.0",
-                          "from": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz",
+                          "from": "utf8@2.1.0",
                           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.0.tgz"
                         }
                       }
                     },
                     "parsejson": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                      "from": "parsejson@0.0.1",
                       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                              "from": "callsite@1.0.0",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -3938,17 +3933,17 @@
                     },
                     "parseqs": {
                       "version": "0.0.2",
-                      "from": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                      "from": "parseqs@0.0.2",
                       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
                       "dependencies": {
                         "better-assert": {
                           "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                           "dependencies": {
                             "callsite": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                              "from": "callsite@1.0.0",
                               "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                             }
                           }
@@ -3957,49 +3952,49 @@
                     },
                     "component-inherit": {
                       "version": "0.0.3",
-                      "from": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+                      "from": "component-inherit@0.0.3",
                       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
                     },
                     "yeast": {
                       "version": "0.1.2",
-                      "from": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+                      "from": "yeast@0.1.2",
                       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz"
                     }
                   }
                 },
                 "component-bind": {
                   "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+                  "from": "component-bind@1.0.0",
                   "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
                 },
                 "component-emitter": {
                   "version": "1.2.0",
-                  "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
+                  "from": "component-emitter@1.2.0",
                   "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz"
                 },
                 "object-component": {
                   "version": "0.0.3",
-                  "from": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+                  "from": "object-component@0.0.3",
                   "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
                 },
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+                  "from": "indexof@0.0.1",
                   "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 },
                 "parseuri": {
                   "version": "0.0.4",
-                  "from": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                  "from": "parseuri@0.0.4",
                   "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
                   "dependencies": {
                     "better-assert": {
                       "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
                       "dependencies": {
                         "callsite": {
                           "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+                          "from": "callsite@1.0.0",
                           "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
                         }
                       }
@@ -4008,49 +4003,49 @@
                 },
                 "to-array": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+                  "from": "to-array@0.1.4",
                   "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz"
                 },
                 "backo2": {
                   "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+                  "from": "backo2@1.0.2",
                   "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
                 }
               }
             },
             "socket.io-adapter": {
               "version": "0.4.0",
-              "from": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
+              "from": "socket.io-adapter@0.4.0",
               "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.4.0.tgz",
               "dependencies": {
                 "socket.io-parser": {
                   "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                  "from": "socket.io-parser@2.2.2",
                   "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
                   "dependencies": {
                     "debug": {
                       "version": "0.7.4",
-                      "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+                      "from": "debug@0.7.4",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
                     },
                     "json3": {
                       "version": "3.2.6",
-                      "from": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz",
+                      "from": "json3@3.2.6",
                       "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
                     },
                     "component-emitter": {
                       "version": "1.1.2",
-                      "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+                      "from": "component-emitter@1.1.2",
                       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "from": "isarray@0.0.1",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "benchmark": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz",
+                      "from": "benchmark@1.0.0",
                       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
                     }
                   }
@@ -4059,24 +4054,24 @@
             },
             "has-binary": {
               "version": "0.1.7",
-              "from": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "from": "has-binary@0.1.7",
               "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
               "dependencies": {
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 }
               }
             },
             "debug": {
               "version": "2.2.0",
-              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "from": "debug@2.2.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
                   "version": "0.7.1",
-                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "from": "ms@0.7.1",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 }
               }
@@ -4085,22 +4080,22 @@
         },
         "spero": {
           "version": "1.3.2",
-          "from": "https://registry.npmjs.org/spero/-/spero-1.3.2.tgz",
+          "from": "spero@>=1.3.0 <1.4.0",
           "resolved": "https://registry.npmjs.org/spero/-/spero-1.3.2.tgz"
         },
         "try-catch": {
           "version": "1.0.0",
-          "from": "https://registry.npmjs.org/try-catch/-/try-catch-1.0.0.tgz",
+          "from": "try-catch@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-1.0.0.tgz"
         },
         "tryrequire": {
           "version": "1.1.5",
-          "from": "https://registry.npmjs.org/tryrequire/-/tryrequire-1.1.5.tgz",
+          "from": "tryrequire@>=1.1.5 <1.2.0",
           "resolved": "https://registry.npmjs.org/tryrequire/-/tryrequire-1.1.5.tgz"
         },
         "writejson": {
           "version": "1.1.1",
-          "from": "https://registry.npmjs.org/writejson/-/writejson-1.1.1.tgz",
+          "from": "writejson@>=1.1.0 <1.2.0",
           "resolved": "https://registry.npmjs.org/writejson/-/writejson-1.1.1.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "archiver": "^1.0.0",
     "base-uri": "^1.0.1",
-    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.19",
+    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.20",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "os-homedir": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "archiver": "^1.0.0",
     "base-uri": "^1.0.1",
-    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.18",
+    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.19",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "os-homedir": "^1.0.1",


### PR DESCRIPTION
This still requires a revert on `cloudcmd` back to the old URL format for downloading files.

**Note:** Also requires `/url/...?download=<something>`, maybe use the timestamp as before to avoid caching.

This will only work on `webdev02.hpc.osc.edu` for now.