### PR TITLE
Release 1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 # Don't include the node modules
 /node_modules/
 
-#.gitignore
+# ignore everyting in tmp but keep tmp dir around
 /tmp/*
 !/tmp/.keep

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A Node.js web based file explorer that is a modification of [CloudCommander](htt
   ```sh
   scl enable git19 -- git clone https://github.com/OSC/ood-fileexplorer.git files
   cd files
-  scl enable git19 -- git checkout tags/v1.3.0
+  scl enable git19 -- git checkout tags/v1.3.1
   ```
 
 
@@ -54,7 +54,7 @@ A Node.js web based file explorer that is a modification of [CloudCommander](htt
 
   ```sh
   scl enable git19 -- git fetch
-  scl enable git19 -- git checkout tags/v1.3.0  # use the latest tag
+  scl enable git19 -- git checkout tags/v1.3.1
   ```
   
 2. Install node dependencies reinstall modules

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
See this for the full file diff:

https://github.com/OSC/ood-fileexplorer/compare/v1.3.0...release_1.3.1

Release notes should be (markdown):

```markdown
### Fixed
- .env is no longer required for installation as defaults are now set in app.js for file upload max, and editor and shell URIs
```