### PR TITLE
v26 Fixes #150 terminal and editor links with symbols in path

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -283,8 +283,8 @@
     },
     "cloudcmd": {
       "version": "5.3.1",
-      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.25",
-      "resolved": "git://github.com/OSC/cloudcmd.git#335cff7331a907c3ebe2706c8095cd20b912c9d9",
+      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.26",
+      "resolved": "git://github.com/OSC/cloudcmd.git#a7794ac69fef2cb380c72550d7272d9aed60b240",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "archiver": "^1.0.0",
     "base-uri": "^1.0.1",
-    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.25",
+    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.26",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "git-rev-sync": "^1.8.0",


### PR DESCRIPTION
Fixes https://github.com/OSC/ood-fileexplorer/issues/150

Incorporates changes made at https://github.com/OSC/cloudcmd/pull/41