### PR TITLE
Fixes #169: crash when git folder missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Upcoming
+
+- Fix crash when the git folder is not present
+
 ## v1.3.6 - 2017-10-24
 
 - update to osc/cloudcmd v5.3.1-osc.29

--- a/app.js
+++ b/app.js
@@ -147,7 +147,7 @@ app.use(cloudcmd({
         upload_max:             process.env.FILE_UPLOAD_MAX || 10485760000,
         file_editor:            process.env.OOD_FILE_EDITOR || '/pun/sys/file-editor/edit',
         shell:                  process.env.OOD_SHELL || '/pun/sys/shell/ssh/default',
-        fileexplorer_version:   gitSync.tag()
+        fileexplorer_version:   app_version
     }
 }));
 

--- a/app.js
+++ b/app.js
@@ -14,6 +14,7 @@ var http        = require('http'),
     dirArray    = __dirname.split('/'),
     PORT        = 9001,
     PREFIX      = '',
+    app_version,
     server,
     socket;
 
@@ -118,6 +119,14 @@ app.use(function (req, res, next) {
         next();
     }
 });
+
+// Set version number
+// TODO: Consider embedding version in project
+try {
+    app_version = gitSync.tag();
+} catch(error) {
+    app_version = '';
+}
 
 // Load cloudcmd
 app.use(cloudcmd({


### PR DESCRIPTION
Fixes #169

Moves the gitSync command to a try/catch to prevent a crash when git folder is missing.

There may be a performance boost afforded by checking to see if a `/.git` folder exists before attempting the try/catch. But this is the simplest solution for now.