### PR TITLE
Tree root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add route for intercepting tree root modification queries and setting variables.
+
 ## v1.3.6 - 2017-10-24
 
 - update to osc/cloudcmd v5.3.1-osc.29
@@ -59,3 +65,5 @@ Bugfixes:
 ## v1.0.0
 
 Initial Release
+
+[Unreleased]: https://github.com/OSC/ood-fileexplorer/compare/v1.3.6...HEAD

--- a/app.js
+++ b/app.js
@@ -14,6 +14,8 @@ var http        = require('http'),
     dirArray    = __dirname.split('/'),
     PORT        = 9001,
     PREFIX      = '',
+    treeroot,
+    treeroottitle,
     server,
     socket;
 
@@ -64,6 +66,16 @@ app.get(BASE_URI + CloudFunc.apiURL + CloudFunc.FS + ':path(*)', function(req, r
     } else {
         next();
     }
+});
+
+// Set the treeroot var if query param available
+app.use(function (req, res, next) {
+     if (req.query.treeroot) {
+         treeroot = req.query.treeroot;
+         next();
+     } else {
+         next();
+     }
 });
 
 // Custom middleware to zip and send a directory to a browser.
@@ -133,8 +145,9 @@ app.use(cloudcmd({
         // each app instance have a separate treeroot
         // treeroot: "/nfs/gpfs/PZS0530",
         // treeroottitle: "Project Space"
-        treeroot:               HOME,
-        treeroottitle:          "Home Directory",
+        home_dir:               HOME,
+        treeroot:               treeroot || HOME,
+        treeroottitle:          treeroottitle || "Home Directory",
         upload_max:             process.env.FILE_UPLOAD_MAX || 10485760000,
         file_editor:            process.env.OOD_FILE_EDITOR || '/pun/sys/file-editor/edit',
         shell:                  process.env.OOD_SHELL || '/pun/sys/shell/ssh/default',

--- a/app.js
+++ b/app.js
@@ -69,7 +69,10 @@ app.get(BASE_URI + CloudFunc.apiURL + CloudFunc.FS + ':path(*)', function(req, r
 // Set the treeroot var if query param available
 app.use(function (req, res, next) {
     if (req.query.treeroot && req.query.treeroot !== "") {
-        process.env.TREEROOT = req.query.treeroot;
+        // Checking the filesystem is expensive, so only do it when the query param is set
+        if (fs.existsSync(req.query.treeroot)) {
+            process.env.TREEROOT = req.query.treeroot;
+        }
     }
     next();
 });

--- a/app.js
+++ b/app.js
@@ -135,12 +135,11 @@ app.use(cloudcmd({
         showKeysPanel: false,         /* disable the buttons at the bottom of the view            */
         root: '/',                    /* set the root path. change to HOME to use homedir         */
         prefix: BASE_URI,             /* base URL or function which returns base URL (optional)   */
-
-        //TODO: could we set this using get params? or post params for when you first "create a session" ?
-        //FIXME: try setting this with get params - or something that will make
-        // each app instance have a separate treeroot
-        // treeroot: "/nfs/gpfs/PZS0530",
-        // treeroottitle: "Project Space"
+        //  Values configured in this block are static and cannot be changed dynamically once the process is launched.
+        // treeroot and treeroottitle are used to set the default values for the file directory tree.
+        // Examples:
+        //    treeroot: "/nfs/gpfs/PZS0530",
+        //    treeroottitle: "Project Space"
         home_dir:               HOME,
         treeroot:               HOME,
         treeroottitle:          "Home Directory",

--- a/app.js
+++ b/app.js
@@ -14,8 +14,6 @@ var http        = require('http'),
     dirArray    = __dirname.split('/'),
     PORT        = 9001,
     PREFIX      = '',
-    treeroot,
-    treeroottitle,
     server,
     socket;
 
@@ -70,12 +68,10 @@ app.get(BASE_URI + CloudFunc.apiURL + CloudFunc.FS + ':path(*)', function(req, r
 
 // Set the treeroot var if query param available
 app.use(function (req, res, next) {
-     if (req.query.treeroot) {
-         treeroot = req.query.treeroot;
-         next();
-     } else {
-         next();
-     }
+    if (req.query.treeroot && req.query.treeroot !== "") {
+        process.env.TREEROOT = req.query.treeroot;
+    }
+    next();
 });
 
 // Custom middleware to zip and send a directory to a browser.
@@ -146,8 +142,8 @@ app.use(cloudcmd({
         // treeroot: "/nfs/gpfs/PZS0530",
         // treeroottitle: "Project Space"
         home_dir:               HOME,
-        treeroot:               treeroot || HOME,
-        treeroottitle:          treeroottitle || "Home Directory",
+        treeroot:               HOME,
+        treeroottitle:          "Home Directory",
         upload_max:             process.env.FILE_UPLOAD_MAX || 10485760000,
         file_editor:            process.env.OOD_FILE_EDITOR || '/pun/sys/file-editor/edit',
         shell:                  process.env.OOD_SHELL || '/pun/sys/shell/ssh/default',

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -37,9 +37,9 @@
           }
         },
         "async": {
-          "version": "2.5.0",
+          "version": "2.6.0",
           "from": "async@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz"
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -164,9 +164,9 @@
           }
         },
         "tar-stream": {
-          "version": "1.5.4",
+          "version": "1.5.5",
           "from": "tar-stream@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
           "dependencies": {
             "bl": {
               "version": "1.2.1",
@@ -270,8 +270,8 @@
     },
     "cloudcmd": {
       "version": "5.3.1",
-      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.29",
-      "resolved": "git://github.com/OSC/cloudcmd.git#b19f86a972e4c127bdec3a4a50c939eb7d7b645b",
+      "from": "git://github.com/OSC/cloudcmd.git#roottree",
+      "resolved": "git://github.com/OSC/cloudcmd.git#72e9b6fc19bb783562da98bc9ab89c1f4a99d985",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -4104,7 +4104,7 @@
           "dependencies": {
             "mime-types": {
               "version": "2.1.17",
-              "from": "mime-types@>=2.1.16 <2.2.0",
+              "from": "mime-types@>=2.1.15 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
               "dependencies": {
                 "mime-db": {
@@ -4371,7 +4371,7 @@
             },
             "mime-types": {
               "version": "2.1.17",
-              "from": "mime-types@>=2.1.16 <2.2.0",
+              "from": "mime-types@>=2.1.15 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
               "dependencies": {
                 "mime-db": {
@@ -4486,9 +4486,9 @@
               }
             },
             "interpret": {
-              "version": "1.0.4",
+              "version": "1.1.0",
               "from": "interpret@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz"
             },
             "rechoir": {
               "version": "0.6.2",
@@ -4496,9 +4496,9 @@
               "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
               "dependencies": {
                 "resolve": {
-                  "version": "1.4.0",
+                  "version": "1.5.0",
                   "from": "resolve@>=1.1.6 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
                   "dependencies": {
                     "path-parse": {
                       "version": "1.0.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -271,7 +271,7 @@
     "cloudcmd": {
       "version": "5.3.1",
       "from": "git://github.com/OSC/cloudcmd.git#roottree",
-      "resolved": "git://github.com/OSC/cloudcmd.git#2ff7a93f1107821c1ad02099f028a4b3905f0d42",
+      "resolved": "git://github.com/OSC/cloudcmd.git#eff7d8af16207d2310ab648b0bf8141321563469",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -117,9 +117,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.4",
+          "version": "4.17.5",
           "from": "lodash@>=4.8.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz"
         },
         "readable-stream": {
           "version": "2.3.3",
@@ -174,9 +174,9 @@
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz"
             },
             "end-of-stream": {
-              "version": "1.4.0",
+              "version": "1.4.1",
               "from": "end-of-stream@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.4.0",
@@ -271,7 +271,7 @@
     "cloudcmd": {
       "version": "5.3.1",
       "from": "git://github.com/OSC/cloudcmd.git#roottree",
-      "resolved": "git://github.com/OSC/cloudcmd.git#72e9b6fc19bb783562da98bc9ab89c1f4a99d985",
+      "resolved": "git://github.com/OSC/cloudcmd.git#2ff7a93f1107821c1ad02099f028a4b3905f0d42",
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
@@ -4141,6 +4141,11 @@
               "from": "http-errors@>=1.6.2 <1.7.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
               "dependencies": {
+                "depd": {
+                  "version": "1.1.1",
+                  "from": "depd@1.1.1",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+                },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@2.0.3",
@@ -4205,14 +4210,14 @@
           }
         },
         "depd": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "from": "depd@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
         },
         "encodeurl": {
-          "version": "1.0.1",
+          "version": "1.0.2",
           "from": "encodeurl@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
         },
         "escape-html": {
           "version": "1.0.3",
@@ -4320,6 +4325,11 @@
               "from": "http-errors@>=1.6.2 <1.7.0",
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
               "dependencies": {
+                "depd": {
+                  "version": "1.1.1",
+                  "from": "depd@1.1.1",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+                },
                 "inherits": {
                   "version": "2.0.3",
                   "from": "inherits@2.0.3",
@@ -4536,9 +4546,9 @@
           }
         },
         "engine.io": {
-          "version": "1.8.4",
+          "version": "1.8.5",
           "from": "engine.io@>=1.8.4 <1.9.0",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.5.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.3.3",
@@ -4602,9 +4612,9 @@
               }
             },
             "ws": {
-              "version": "1.1.4",
-              "from": "ws@1.1.4",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
+              "version": "1.1.5",
+              "from": "ws@>=1.1.5 <1.2.0",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
               "dependencies": {
                 "options": {
                   "version": "0.0.6",
@@ -4668,9 +4678,9 @@
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
             },
             "engine.io-client": {
-              "version": "1.8.4",
+              "version": "1.8.5",
               "from": "engine.io-client@>=1.8.4 <1.9.0",
-              "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz",
+              "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.5.tgz",
               "dependencies": {
                 "component-inherit": {
                   "version": "0.0.3",
@@ -4753,9 +4763,9 @@
                   }
                 },
                 "ws": {
-                  "version": "1.1.2",
-                  "from": "ws@1.1.2",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
+                  "version": "1.1.5",
+                  "from": "ws@>=1.1.5 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
                   "dependencies": {
                     "options": {
                       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "archiver": "^1.0.0",
     "base-uri": "^1.0.1",
-    "cloudcmd": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.29",
+    "cloudcmd": "git://github.com/OSC/cloudcmd.git#roottree",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
     "git-rev-sync": "^1.8.0",


### PR DESCRIPTION
Resolves #166 
Also fixes #173 in conjunction with cloudcmd update

This PR is in a testable state.

This branch is currently set to access the `roottree` branch of cloudcmd. Once the changes are approved, the `cloudcmd` app will need a version update and this PR will need an update to reference that version and the npm-shrinkwrap will need modification.

For now, evaluation can be performed by switching to the `treeroot` branch of file explorer and performing an `npm i` command.