### PR TITLE
[WIP] whitelist dirs for initial dir load

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -270,7 +270,7 @@
     },
     "cloudcmd": {
       "version": "5.3.1",
-      "from": "git://github.com/OSC/cloudcmd.git#v5.3.1-osc.29",
+      "from": "git://github.com/OSC/cloudcmd.git#b19f86a972e4c127bdec3a4a50c939eb7d7b645b",
       "resolved": "git://github.com/OSC/cloudcmd.git#b19f86a972e4c127bdec3a4a50c939eb7d7b645b",
       "dependencies": {
         "chalk": {
@@ -4089,7 +4089,7 @@
     },
     "dotenv": {
       "version": "4.0.0",
-      "from": "dotenv@4.0.0",
+      "from": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz"
     },
     "express": {
@@ -4512,6 +4512,11 @@
           }
         }
       }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "from": "lodash@latest",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
     },
     "os-homedir": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dotenv": "^4.0.0",
     "express": "^4.13.4",
     "git-rev-sync": "^1.8.0",
+    "lodash": "^4.17.10",
     "os-homedir": "^1.0.1",
     "socket.io": "^1.4.5"
   },


### PR DESCRIPTION
**Hold off till upgrading node.js to rh-nodejs6**

for the initial request to load the app, this middleware
filters the requested path through a whitelist if provided

this doesn't address directory changes due to AJAX calls or
content download requests of directories due to zip, and might not
address other AJAX requests like fetching and saving the content
of a file by the file editor

also, it uses lodash, but this should probably be replaced by built in
methods after upgrading node.js