### PR TITLE
Support whitelisting dirs

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ var http        = require('http'),
 // Read in environment variables
 dotenv.config({path: '.env.local'});
 if (process.env.NODE_ENV === 'production') {
-  dotenv.config({path: '/etc/ood/config/apps/files/env'});
+    dotenv.config({path: '/etc/ood/config/apps/files/env'});
 }
 
 var WHITELIST_PATHS = process.env.WHITELIST ? process.env.WHITELIST.split(":") : [];
@@ -36,8 +36,8 @@ var whitelist_paths_contain = (function(filepath){
 
 // Keep app backwards compatible
 if (fs.existsSync('.env')) {
-  console.warn('[DEPRECATION] The file \'.env\' is being deprecated. Please move this file to \'/etc/ood/config/apps/files/env\'.');
-  dotenv.config({path: '.env'});
+    console.warn('[DEPRECATION] The file \'.env\' is being deprecated. Please move this file to \'/etc/ood/config/apps/files/env\'.');
+    dotenv.config({path: '.env'});
 }
 
 server = http.createServer(app);

--- a/lib/cloudcmd/lib/server/rest.js
+++ b/lib/cloudcmd/lib/server/rest.js
@@ -213,12 +213,17 @@
                     data    = files.names.slice();
                 else
                     data    = files;
+
+                if (config('whitelist') && ! (config('whitelist').contains(files.from) && config('whitelist').contains(files.to))) {
+                    callback(Error("EACCES: permission denied, rename '" + files.from + "' -> '" + files.to + "'"));
+                }
+                else {
+                    copyFiles(files, flop.move, function(error) {
+                        var msg = formatMsg('move', data);
                     
-                copyFiles(files, flop.move, function(error) {
-                    var msg = formatMsg('move', data);
-                    
-                    callback(error, msg);
-                });
+                        callback(error, msg);
+                    });
+                }
             }
             
             break;
@@ -233,10 +238,15 @@
                 files.to    = root(files.to);
                 
                 msg         = formatMsg('copy', files.names);
-                
-                copy(files.from, files.to, files.names, function(error) {
-                    callback(error, msg);
-                });
+
+                if (config('whitelist') && ! (config('whitelist').contains(files.from) && config('whitelist').contains(files.to))) {
+                    callback(Error("EACCES: permission denied, copy '" + files.from + "' -> '" + files.to + "'"));
+                }
+                else {
+                    copy(files.from, files.to, files.names, function(error) {
+                        callback(error, msg);
+                    });
+                }
             }
             break;
         

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "archiver": "^1.0.0",
     "base-uri": "^1.0.1",
     "dotenv": "^4.0.0",
+    "expand-tilde": "^2.0.2",
     "express": "^4.13.4",
     "git-rev-sync": "^1.8.0",
     "os-homedir": "^1.0.1",
@@ -28,5 +29,7 @@
   "scripts": {
     "test": "test"
   },
-  "workspaces": ["lib/cloudcmd"]
+  "workspaces": [
+    "lib/cloudcmd"
+  ]
 }


### PR DESCRIPTION
There are definitely cleaner ways to do this, or more robust ways.

Two UX fixes:

- [ ] 1. Try to download a zip of the selected directory that is not in the whitelist, and a 403 error occurs but a "Forbidden" error alert doesn't display like in the other Ajax requests that get a 403.
- [ ] 2. If doing a non AJAX request (like enter the forbidden URL into the browser) instead of the page showing "forbidden" it should probably present a list of links the user can access (the whitelisted directories) or go to home directory (or root directory that is set for the tree).

A more robust solution would be to add checks at the source - the actual code that hits the filesystem could raise the same exceptions that occur when a file or directory is actually not readable by a user. But that would take more time than this.