### PR TITLE
Disable caching for GET / HEAD requests

### DIFF
--- a/lib/cloudcmd/lib/client/rest.js
+++ b/lib/cloudcmd/lib/client/rest.js
@@ -182,6 +182,7 @@ var Util, DOM, CloudFunc, CloudCmd;
             p.url   = p.url.replace('#', '%23');
             
             DOM.load.ajax({
+                cache       : false,
                 method      : p.method,
                 url         : p.url,
                 data        : p.data,


### PR DESCRIPTION
Caching was causing confusing behavior where Viewed files would only appear updated after refreshing the tab. Quoting the jQuery AJAX docs about the caching key:

   If set to false, it will force requested pages not to be cached by the browser. Note: Setting cache to false will only work correctly with HEAD and GET requests. It works by appending "_={timestamp}" to the GET parameters. The parameter is not needed for other types of requests, except in IE8 when a POST is made to a URL that has already been requested by a GET.

Fixes #194.