### PR TITLE
[EXAMPLE] - Reject XML reserved characters from new file paths

### DIFF
--- a/lib/cloudcmd/lib/client/load.js
+++ b/lib/cloudcmd/lib/client/load.js
@@ -221,6 +221,19 @@
         load.put = function(url, body) {
             var emitter = Emitify(),
                 xhr     = new XMLHttpRequest();
+
+            // !! OSC CUSTOM CODE !!
+            if( ! filePathIsAcceptable(url) ) {
+                setTimeout(function() {
+                    DOM.Dialog.alert(
+                        CloudCmd.TITLE,
+                        'Refusing to upload file with ' + UNACCEPTABLE_CHAR_MSG + ' in the name.'
+                    );
+                }, 100);
+
+                return emitter;
+            }
+            // END OSC CUSTOM
             
             url     = encodeURI(url);
             url     = url.replace('#', '%23');

--- a/lib/cloudcmd/lib/client/ood.js
+++ b/lib/cloudcmd/lib/client/ood.js
@@ -172,3 +172,21 @@ function download() {
                 DOM.toggleSelectedFile(file);
         });
 }
+
+/**
+ * Validate whether the path basename could break the front end.
+ *
+ * !! OSC CUSTOM CODE !!
+ *
+ * Files or directories with XML/HTML in their names may break the
+ * front end of the file explorer, and may need to be blocked.
+ *
+ * @param      String  name    The path basename to validate
+ * @return     Boolean
+ */
+function filePathIsAcceptable(name) {
+    return ! name.match(/[<>&"]/);
+}
+
+// Used in messages to the user
+const UNACCEPTABLE_CHAR_MSG = '<, >, &, or "';

--- a/lib/cloudcmd/lib/client/rest.js
+++ b/lib/cloudcmd/lib/client/rest.js
@@ -49,6 +49,19 @@ var Util, DOM, CloudFunc, CloudCmd;
         
         this.write   = function(url, data, callback) {
             var isFunc      = Util.type.function(data);
+
+            // !! OSC CUSTOM CODE !!
+            if( ! filePathIsAcceptable(url) ) {
+                setTimeout(function() {
+                    DOM.Dialog.alert(
+                        CloudCmd.TITLE,
+                        'Refusing to create new file/directory with ' + UNACCEPTABLE_CHAR_MSG + ' in the name.'
+                    );
+                }, 100);
+
+                return;
+            }
+            // END OSC CUSTOM
             
             if (!callback && isFunc) {
                 callback    = data;
@@ -86,6 +99,19 @@ var Util, DOM, CloudFunc, CloudCmd;
         };
         
          this.cp     = function(data, callback) {
+            // !! OSC CUSTOM CODE !!
+            if( ! filePathIsAcceptable(data.to) ) {
+                setTimeout(function() {
+                    DOM.Dialog.alert(
+                        CloudCmd.TITLE,
+                        'Refusing to copy to file/directory with ' + UNACCEPTABLE_CHAR_MSG + ' in the name.'
+                    );
+                }, 100);
+
+                return;
+            }
+            // END OSC CUSTOM
+
             sendRequest({
                 method      : 'PUT',
                 url         : '/cp',
@@ -114,6 +140,19 @@ var Util, DOM, CloudFunc, CloudCmd;
         };
         
         this.mv     = function(data, callback) {
+            // !! OSC CUSTOM CODE !!
+            if( ! filePathIsAcceptable(data.to) ) {
+                setTimeout(function() {
+                    DOM.Dialog.alert(
+                        CloudCmd.TITLE,
+                        'Refusing to rename file/directory with ' + UNACCEPTABLE_CHAR_MSG + ' in the name.'
+                    );
+                }, 100);
+
+                return;
+            }
+            // END OSC CUSTOM
+
             sendRequest({
                 method      : 'PUT',
                 url         : '/mv',


### PR DESCRIPTION
XML/HTML partials are valid in file names, however our version of CloudCmd does not handle them gracefully; they can break the frontend completely. The naive fix is to simply reject these file names at the frontend.

Consider the following cases:
- `<a href='https://www.google.com' />`
- `<script>window.alert('hacked');</script>`
- `<script>window.alert("hacked");</script>`

I do not love this solution because it rejects file names that are valid as far as the file system is concerned. With that said, this solution is acceptable given that we are talking about replacing this application in the near to mid-term.

Fixes #198.